### PR TITLE
✨ feat: Main 페이지 todayInfo API 연결

### DIFF
--- a/grass-diary/package-lock.json
+++ b/grass-diary/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@stylexjs/stylex": "^0.5.1",
+        "axios": "^1.6.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0",
@@ -1533,6 +1534,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
@@ -1542,6 +1548,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1662,6 +1678,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compare-versions": {
       "version": "6.1.0",
@@ -1785,6 +1812,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -2380,12 +2415,44 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3188,6 +3255,25 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3541,6 +3627,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/grass-diary/package.json
+++ b/grass-diary/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.5.1",
+    "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -1,5 +1,7 @@
 import * as stylex from '@stylexjs/stylex';
 import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import mainCharacter from '../../assets/icon/mainCharacter.png';
 import Header from '../../components/Header';
 import SimpleSlider from './CardSlider';
@@ -236,6 +238,21 @@ const BottomSectionStyle = stylex.create({
 });
 
 const TopSection = () => {
+  const [date, setDate] = useState(null);
+  const [todayQuestion, setTodayQuestion] = useState(null);
+
+  useEffect(() => {
+    axios
+      .get('http://localhost:8080/api/main/todayInfo')
+      .then(response => {
+        setDate(response.data.date);
+        setTodayQuestion(response.data.todayQuestion);
+      })
+      .catch(error => {
+        console.log('Error', error);
+      });
+  }, []);
+
   const modal = () => {
     Swal.fire({
       title: '교환 일기장',
@@ -248,6 +265,7 @@ const TopSection = () => {
       confirmButtonText: '확인',
     });
   };
+
   return (
     <>
       <div {...stylex.props(TopSectionStyles.container)}>
@@ -257,13 +275,11 @@ const TopSection = () => {
               className="fa-solid fa-lightbulb"
               style={{ paddingBottom: '20px' }}
             ></i>
-            <div>오늘은</div>
-            <div>11월 11일</div>
-            <div>빼빼로 데이입니다</div>
+            <div>{date ? <p>{date}</p> : <p>Loading...</p>}</div>
           </div>
           <div style={{ display: 'flex', gap: '10px' }}>
             <i className="fa-solid fa-circle-question"></i>
-            <div>오늘 잠을 얼마나 잤나요?</div>
+            <div>{todayQuestion ? <>{todayQuestion}</> : <>Loading...</>}</div>
           </div>
           <Link to="/creatediary">
             <button {...stylex.props(TopSectionStyles.writeButton)}>


### PR DESCRIPTION
## API 연결 axios

| | axios | fetch |
|---|---|---|
|설치 필요 여부|써드파티 라이브러리로 설치 필요|현대 브라우저에 빌트인이라 설치 필요 없음|
|XSRF 보호|XSRF 보호를 제공함|별도 보호 없음|
|데이터 속성|data 속성을 사용|body 속성을 사용|
|데이터 형식|data는 object를 포함함|body는 문자열화 되어있음|
|성공 여부 판단|status가 200이고 statusText가 ‘OK’이면 성공|응답객체가 ok 속성을 포함하면 성공|
|JSON 변환|자동으로 JSON데이터 형식으로 변환| .json()메서드를 사용해야 함|
|요청 취소/타임아웃|요청을 취소할 수 있고 타임아웃을 걸 수 있음|해당 기능 존재하지 않음|
|HTTP 요청 가로채기|HTTP 요청을 가로챌 수 있음|기본적으로 제공하지 않음|
|다운로드 진행 지원|download진행에 대해 기본적인 지원을 함|지원하지 않음|
|브라우저 지원 범위|좀더 많은 브라우저에 지원됨|Chrome 42+, Firefox 39+, Edge 14+, and Safari 10.1+이상에 지원|

위 표를 보았을 때, axios는 별도의 설치가 필요하다는 단점이 있지만 그것을 커버할 만한 fetch보다 많은 기능 지원과 문법이 간소화되어 있다는 장점이 있습니다. 따라서, 간단하게 사용할 때는 fetch를, 확장성을 염두에 두고 있다면 axios를 사용하는 것이 좋습니다.

<br>

### axios 사용

<br>

React

```javascript
  const [date, setDate] = useState(null);
  const [todayQuestion, setTodayQuestion] = useState(null);

  useEffect(() => {
    axios
      .get('http://localhost:8080/api/main/todayInfo')
      .then(response => {
        setDate(response.data.date);
        setTodayQuestion(response.data.todayQuestion);
      })
      .catch(error => {
        console.log('Error', error);
      });
  }, []);
```

```javascript
useEffect(() => {
axios
}, []);
```
- `uesEffect`와 코드 마지막에 의존성 배열 `[ ]` 을 넣어줌으로써 API 호출을 한 번만 실행하게 합니다.

localhost:8080/api/main/todayInfo

```java
{
"date": "string"
"todayQuestion": "string"
}
```

<br>

### CORS

Spring error message
```java
Caused by: java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header. To allow credentials to a set of origins, list them explicitly or consider using "allowedOriginPatterns" instead.
```

allowCredentials가 true로 설정되어 있는데 allowedOrigins에 특수 값인 * (모든 출처를 의미)이 포함되어 있기 때문에 문제가 발생했습니다. Access-Control-Allow-Origin 헤더는 * 값을 가질 수 없기 때문입니다.

즉, allowCredentials가 true인 경우, allowedOrigins는 명시적으로 허용할 출처를 나열해야 하며, *를 사용할 수 없습니다. 특정 패턴을 가진 출처를 허용하려면 allowedOriginPatterns를 사용해야 합니다.

따라서 해결 방법은 두 가지입니다:

1. allowedOrigins에 특정 출처를 명시적으로 허용하도록 변경합니다.
2. allowedOrigins 대신 allowedOriginPatterns를 사용하여 특정 패턴을 가진 출처를 허용하도록 설정합니다.
아래는 수정된 CORS 설정 예시입니다

```java
@Configuration
public class WebConfig implements WebMvcConfigurer {

    @Override
    public void addCorsMappings(CorsRegistry registry) {
        registry.addMapping("/**")
                .allowedOrigins("http://localhost:3000") // 명시적인 출처 지정
                .allowedMethods("*")
                .allowedHeaders("*")
                .allowCredentials(true); // allowCredentials 추가
    }
}

```