### PR TITLE
✨ feat: 구글 간편 로그인 API 연동 (CLIENT-67)

### DIFF
--- a/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
+++ b/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
@@ -94,6 +94,10 @@ const LoginModal = ({ isOpen, isClose }) => {
     return null;
   }
 
+  const handleGoogleLogin = () => {
+    window.open('http://localhost:8080/api/auth/google', '_self');
+  };
+
   return (
     <div {...stylex.props(styles.container)}>
       <div {...stylex.props(styles.background)} onClick={isClose}></div>
@@ -105,7 +109,7 @@ const LoginModal = ({ isOpen, isClose }) => {
           </button>
         </div>
         <div {...stylex.props(styles.modalContent)}>
-          <button {...stylex.props(styles.button)}>
+          <button {...stylex.props(styles.button)} onClick={handleGoogleLogin}>
             <img {...stylex.props(styles.buttonImage)} src={googleButton}></img>
           </button>
         </div>


### PR DESCRIPTION
## 구글 간편 로그인 API 연동 (CLIENT-67)
### 🔎 AS-IS

- 현재 사용자가 로그인 모달 내에 있는 구글 로그인 버튼을 클릭했을 때 구글 로그인 페이지로 이동하지 못하고 있습니다. 따라서 구글 간편 로그인 API 연결이 필요합니다.

### ✨ TO-BE

- [x] 사용자가 로그인 버튼 클릭 시 구글 로그인 화면으로 이동할 수 있도록 API를 연결한다.