### PR TITLE
✨ feat: 액세스 토큰 API 헤더에 삽입 (CLIENT-76)

### DIFF
--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -183,8 +183,15 @@ const Diary = () => {
   const userName = 'user name';
 
   useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    const config = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
     axios
-      .get('http://localhost:8080/api/diary/16')
+      .get('http://localhost:8080/api/diary/16', config)
       .then(response => {
         console.log(response);
       })

--- a/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
+++ b/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
@@ -94,6 +94,10 @@ const LoginModal = ({ isOpen, isClose }) => {
     return null;
   }
 
+  const handleGoogleLogin = () => {
+    window.open('http://localhost:8080/api/auth/google', '_self');
+  };
+
   return (
     <div {...stylex.props(styles.container)}>
       <div {...stylex.props(styles.background)} onClick={isClose}></div>
@@ -105,7 +109,7 @@ const LoginModal = ({ isOpen, isClose }) => {
           </button>
         </div>
         <div {...stylex.props(styles.modalContent)}>
-          <button {...stylex.props(styles.button)}>
+          <button {...stylex.props(styles.button)} onClick={handleGoogleLogin}>
             <img {...stylex.props(styles.buttonImage)} src={googleButton}></img>
           </button>
         </div>

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -241,9 +241,16 @@ const TopSection = () => {
   const [date, setDate] = useState(null);
   const [todayQuestion, setTodayQuestion] = useState(null);
 
+  const token = localStorage.getItem('accessToken');
+  const config = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
   useEffect(() => {
     axios
-      .get('http://localhost:8080/api/main/todayInfo')
+      .get('http://localhost:8080/api/main/todayInfo', config)
       .then(response => {
         setDate(response.data.date);
         setTodayQuestion(response.data.todayQuestion);
@@ -450,6 +457,11 @@ const BottomSection = () => {
 };
 
 const Main = () => {
+  const params = new URLSearchParams(window.location.search);
+  const ACCESS_TOKEN = params.get('accessToken');
+
+  localStorage.setItem('accessToken', ACCESS_TOKEN);
+
   return (
     <>
       <Header />

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -63,9 +63,16 @@ const ToggleButton = ({ buttonLabel, handleToggleButton }) => {
 const Profile = () => {
   const [profile, setProfile] = useState([]);
 
+  const token = localStorage.getItem('accessToken');
+  const config = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
   useEffect(() => {
     axios
-      .get('http://localhost:8080/api/member/profile/1')
+      .get('http://localhost:8080/api/member/profile/1', config)
       .then(response => {
         setProfile(response.data);
       })
@@ -189,8 +196,15 @@ const Diary = () => {
   ];
 
   useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    const config = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
     axios
-      .get(`http://localhost:8080/api/diary/main/1`)
+      .get(`http://localhost:8080/api/diary/main/1`, config)
       .then(response => {
         setDiaryList(response.data.content);
       })


### PR DESCRIPTION
## 액세스 토큰 API 헤더에 삽입 (CLIENT-76)
### 🔎 AS-IS

- 현재 사용자가 회원가입/로그인을 완료한 후 메인 페이지로 이동했을 때, 로그인한 사용자의 데이터를 불러오지 못하고 있습니다. 따라서 사용자 고유 액세스 토큰을 인가받기 위해 요청 API의 헤더에 삽입해야 합니다.

### ✨ TO-BE

- [x] Local Storage에 현재 로그인한 사용자의 액세스 토큰을 저장한다.
- [x] Local Storage에 저장된 액세스 토큰을 API 요청 시에 헤더에 싣어 서버로 전달한다.