### PR TITLE
🔨 fix: 메인 페이지 URL에서 액세스 토큰 숨김

### DIFF
--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -567,10 +567,18 @@ const BottomSection = () => {
 };
 
 const Main = () => {
-  const params = new URLSearchParams(window.location.search);
-  const ACCESS_TOKEN = params.get('accessToken');
 
-  localStorage.setItem('accessToken', ACCESS_TOKEN);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get('accessToken');
+
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
+
+      const mainURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+      window.history.pushState({ path: mainURL }, null, mainURL);
+    }
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## 메인 페이지 URL에서 액세스 토큰 숨김 (CLIENT-77)
### 🚨 AS-IS

현재 사용자가 로그인 시 메인 페이지로 redirect되는 과정에서 메인 페이지 URL에 담긴 액세스 토큰이 사라지지 않고 노출되고 있습니다. 따라서 정보 탈취를 방지하기 위해 URL에서 액세스 토큰을 숨기는 작업이 필요합니다.

### 🔨 TO-BE

- [x] 메인 페이지 redirect 시 액세스 토큰이 싣어져 나타나는 URL을 메인 페이지 URL로 변경한다. 
> 페이지를 새로 고침 하지 않고도 브라우저의 주소 표시줄에 표시되는 URL을 변경할 수 있습니다.
> https://developer.mozilla.org/ko/docs/Web/API/History/pushState

### 🧐 고민해 봐야 할 점

- Local Storage에 사용자의 `AccessToken`을 저장한 뒤 메인 페이지의 URL로 변경시키고 있기 때문에, 로그인이 완료되고 메인 페이지로 redirect 되는 과정에서 아주 짧은 시간 동안 `AccessToken`이 노출되고 있습니다. 때문에 `Cookie` 사용 또는 `OAuth Authorization Code Flow` 등의 대안을 고려해 봐야 할 것 같습니다. 🏃