### PR TITLE
:sparkles: feat: 로그인 미완료 사용자의 페이지 접근 제한 추가

### DIFF
--- a/grass-diary/src/components/ProtectedRoute.jsx
+++ b/grass-diary/src/components/ProtectedRoute.jsx
@@ -1,0 +1,9 @@
+import { Outlet, Navigate } from 'react-router-dom';
+import { checkAuth } from '../utils/checkAuth';
+
+const ProtectedRoute = () => {
+  const isAthenticated = checkAuth();
+  return isAthenticated ? <Outlet /> : <Navigate to="/" />;
+};
+
+export default ProtectedRoute;

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import AnimateReward from './AnimateReward';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import mainCharacter from '../../assets/icon/mainCharacter.png';
@@ -8,6 +8,7 @@ import Header from '../../components/Header';
 import SimpleSlider from './CardSlider';
 import Swal from 'sweetalert2';
 import dayjs from 'dayjs';
+import { checkAuth } from '../../utils/checkAuth';
 
 const styles = stylex.create({
   title: {
@@ -567,6 +568,8 @@ const BottomSection = () => {
 };
 
 const Main = () => {
+  const navigate = useNavigate();
+  const isAthenticated = checkAuth();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -578,6 +581,8 @@ const Main = () => {
       const mainURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
       window.history.pushState({ path: mainURL }, null, mainURL);
     }
+
+    if (!isAthenticated) navigate('/');
   }, []);
 
   return (

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -567,10 +567,18 @@ const BottomSection = () => {
 };
 
 const Main = () => {
-  const params = new URLSearchParams(window.location.search);
-  const ACCESS_TOKEN = params.get('accessToken');
 
-  localStorage.setItem('accessToken', ACCESS_TOKEN);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get('accessToken');
+
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
+
+      const mainURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+      window.history.pushState({ path: mainURL }, null, mainURL);
+    }
+  }, []);
 
   return (
     <>

--- a/grass-diary/src/router.jsx
+++ b/grass-diary/src/router.jsx
@@ -6,6 +6,7 @@ import Diary from './pages/Diary/Diary';
 import Share from './pages/Share/Share';
 import Setting from './pages/Setting/Setting';
 import MyPage from './pages/MyPage/MyPage';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
   {
@@ -17,24 +18,14 @@ const router = createBrowserRouter([
     element: <Main />,
   },
   {
-    path: '/creatediary',
-    element: <CreateDiary />,
-  },
-  {
-    path: '/diary/:id',
-    element: <Diary />,
-  },
-  {
-    path: '/share',
-    element: <Share />,
-  },
-  {
-    path: '/setting',
-    element: <Setting />,
-  },
-  {
-    path: '/mypage',
-    element: <MyPage />,
+    element: <ProtectedRoute />,
+    children: [
+      { path: '/creatediary', element: <CreateDiary /> },
+      { path: '/diary/:id', element: <Diary /> },
+      { path: '/share', element: <Share /> },
+      { path: '/setting', element: <Setting /> },
+      { path: '/mypage', element: <MyPage /> },
+    ],
   },
 ]);
 

--- a/grass-diary/src/utils/checkAuth.js
+++ b/grass-diary/src/utils/checkAuth.js
@@ -1,0 +1,4 @@
+export const checkAuth = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  return !!accessToken;
+};


### PR DESCRIPTION
## 로그인 미완료 사용자의 페이지 접근 제한 추가 (CLIENT-78)
### 🔎 AS-IS

- 현재 로그인을 완료하지 않은 사용자가 URL에 해당 페이지의 router를 추가하면, 로그인을 하지 않은 상태임에도 불구하고 해당 페이지로 이동 가능한 현상이 발생하고 있습니다. 따라서 페이지 접근 제한이 필요합니다.

### ✨ TO-BE

- [x] 사용자가 로그인하지 않고 다른 페이지에 접근하려고 할 경우, 인트로 페이지('/')로 강제로 이동시킨다.

> Outlet은 컴포넌트 내에 자식 라우트의 컴포넌트를 렌더링하는 자리 표시자 역할을 합니다. 즉, 부모 라우트 컴포넌트 안에서 Outlet을 배치하면, 해당 위치에 현재 URL에 해당하는 자식 라우트 컴포넌트가 렌더링됩니다. React Router v6 이상에서는 이 Outlet을 사용하여 중첩 라우팅을 구현합니다. Outlet은 공통적인 레이아웃을 유지하면서도 URL에 따라 다른 컨텐츠를 유연하게 표시할 수 있습니다.
> https://hsly22xk.tistory.com/405