### PR TITLE
:sparkles: feat: 액세스 토큰 만료 시 localStorage에 저장 중인 액세스 토큰 삭제

### DIFF
--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -559,21 +559,25 @@ const BottomSection = () => {
 
 const Main = () => {
   const navigate = useNavigate();
-  const isAthenticated = checkAuth();
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const accessToken = params.get('accessToken');
+    const initLoad = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const accessToken = params.get('accessToken');
 
-    if (accessToken) {
-      localStorage.setItem('accessToken', accessToken);
+      if (accessToken) {
+        localStorage.setItem('accessToken', accessToken);
 
-      const mainURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
-      window.history.pushState({ path: mainURL }, null, mainURL);
-    }
+        const mainURL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+        window.history.pushState({ path: mainURL }, null, mainURL);
+      }
 
-    if (!isAthenticated) navigate('/');
-  }, []);
+      const isAuthenticated = await checkAuth();
+      if (!isAuthenticated) navigate('/');
+    };
+
+    initLoad();
+  }, [navigate]);
 
   return (
     <>

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -431,16 +431,16 @@ const MiddleSection = () => {
       });
   }, []);
 
-  useEffect(() => {
-    API.get('/main/grass/1')
-      .then(response => {
-        setGrassCount(response.data.count);
-        setGrassColor(response.data.grassInfoDTO.colorRGB);
-      })
-      .catch(error => {
-        console.log('Error', error);
-      });
-  }, []);
+  // useEffect(() => {
+  //   API.get('/main/grass/1')
+  //     .then(response => {
+  //       setGrassCount(response.data.count);
+  //       setGrassColor(response.data.grassInfoDTO.colorRGB);
+  //     })
+  //     .catch(error => {
+  //       console.log('Error', error);
+  //     });
+  // }, []);
 
   const modal = () => {
     Swal.fire({

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -188,7 +188,7 @@ const Diary = () => {
   ];
 
   useEffect(() => {
-    API.get(`/diary/main/1`, config)
+    API.get(`/diary/main/1`)
       .then(response => {
         setDiaryList(response.data.content);
       })

--- a/grass-diary/src/services/index.js
+++ b/grass-diary/src/services/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { clearAuth } from '../utils/authUtils';
 
 const API = axios.create({
   baseURL: 'http://localhost:8080/api',
@@ -13,6 +14,17 @@ API.interceptors.request.use(
   },
 
   error => Promise.reject(error),
+);
+
+API.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 500) {
+      clearAuth();
+    }
+
+    return Promise.reject(error);
+  },
 );
 
 export default API;

--- a/grass-diary/src/utils/authUtils.js
+++ b/grass-diary/src/utils/authUtils.js
@@ -2,3 +2,9 @@ export const checkAuth = () => {
   const accessToken = localStorage.getItem('accessToken');
   return !!accessToken;
 };
+
+const clearAuth = () => {
+  localStorage.removeItem('accessToken');
+};
+
+export { checkAuth, clearAuth };

--- a/grass-diary/src/utils/authUtils.js
+++ b/grass-diary/src/utils/authUtils.js
@@ -1,6 +1,8 @@
-export const checkAuth = () => {
+const checkAuth = async () => {
   const accessToken = localStorage.getItem('accessToken');
-  return !!accessToken;
+  if (accessToken) return true;
+
+  return false;
 };
 
 const clearAuth = () => {


### PR DESCRIPTION
## 액세스 토큰 만료 시 localStorage에 저장 중인 액세스 토큰 삭제 (CLIENT-82)
### 🔎 AS-IS

- 현재 로그인한 사용자의 AccessToken이 만료되어도 localStorage에서 삭제되지 않고 남아 있습니다. 따라서  만료된 토큰을 삭제하는 작업이 필요합니다.

### ✨ TO-BE

- [x] AccessToken이 만료될 시 localStorage에서 저장되어 있던 AccessToken을 삭제한다.

### 👀 추가적인 사항

- 현재 사용자의 잔디 현황 요청 API의 응답에서 `Internal Server Error (500)`이 발생하고 있어 임시 주석 처리를 해 둔 상태입니다. 🥺 (액세스 토큰을 삭제하는 조건이 `Internal Server Error (500)`이 발생한 경우이기 때문)
- 사용자가 로그인 시 메인 페이지로 한 번에 넘어가지 않고 인트로 페이지로 되돌아오는 현상이 발생해 localStorage 내의 `AccessToken` 존재 여부를 판단해 주는 `checkAuth()` 함수를 비동기로 변경한 뒤 적용해 주었습니다. 