### PR TITLE
:sparkles: feat: 로그인 상태에 따른 일기 시작하기 버튼 동작 변경

### DIFF
--- a/grass-diary/src/pages/Intro/introComponents.jsx
+++ b/grass-diary/src/pages/Intro/introComponents.jsx
@@ -5,6 +5,10 @@ import Button from '../../components/Button';
 import LoginModal from './LoginModal/LoginModal';
 import useModal from '../../hooks/useModal';
 
+import { checkAuth } from '../../utils/authUtils';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 const Container = ({ children }) => {
   return <div {...stylex.props(styles.container)}>{children}</div>;
 };
@@ -16,19 +20,35 @@ const Section = ({ backgroundColor, height, children }) => (
 );
 
 const OpenModalButton = () => {
+  const navigate = useNavigate();
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const loggedIn = async () => {
+      const accessToken = await checkAuth();
+      if (accessToken) setIsLoggedIn(true);
+    };
+
+    loggedIn();
+  }, []);
+
+  const handleStartButton = () => {
+    if (isLoggedIn) navigate('/main');
+    else handleOpenModal();
+  };
 
   return (
     <>
       <Button
         text="일기 시작하기"
-        onClick={handleOpenModal}
+        onClick={handleStartButton}
         width="150px"
         color="#FFF"
         backgroundColor="#28CA3B"
         border="none"
       />
-      {isModalOpen && (
+      {!isLoggedIn && isModalOpen && (
         <LoginModal isOpen={handleOpenModal} isClose={handleCloseModal} />
       )}
     </>


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 로그인을 완료한 사용자가 인트로 페이지에 접근했을 때, 로그인이 되어 있음에도 불구하고 일기 시작하기 버튼 클릭 시 회원가입 및 로그인 모달이 나타나고 있습니다. 따라서 로그인 상태에 따라 일기 시작하기 버튼의 동작을 변경해 주어야 합니다.

## ✨ TO-BE

- [x] 서비스에 로그인이 되어 있는 사용자가 인트로 페이지의 일기 시작하기 버튼을 클릭할 시 바로 메인 페이지로 이동한다.
- [x] 서비스에 로그인하지 않은 사용자에게는 일기 시작하기 버튼 클릭 시 회원가입 및 로그인 모달이 나타난다.