### PR TITLE
✨ feat: 상세, 공유페이지 api 요청 및 무한스크롤 구현 

### DIFF
--- a/grass-diary/src/components/Like.jsx
+++ b/grass-diary/src/components/Like.jsx
@@ -1,5 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import API from '../services';
 
 const pushLike = stylex.keyframes({
   '0%': { fontSize: '19px' },
@@ -38,12 +39,41 @@ const styles = stylex.create({
   },
 });
 
-const Like = ({ likeCount }) => {
-  const [like, setlike] = useState(false);
+const Like = ({ likeCount, setLikeCount }) => {
+  const [initLike, setInitLike] = useState(false); // true이면 이미 누른 견적 있음. delete 가능 false => 한번도 누르지 않음 post 가능
+  const [like, setlike] = useState(false); // ture=> 하트 눌려있는 상태. delete 가능 상태, false => 하트 안눌린 상태. post 가능 상태
 
-  const clickLike = e => {
-    setlike(current => !current);
+  const clickLike = () => {
+    if (like) {
+      API.delete(`/diary/like/22/1`)
+        .then(() => {
+          setlike(false);
+          setLikeCount(prev => (prev -= 1));
+          console.log('좋아요 취소');
+        })
+        .catch(err => {
+          console.log('like delete error', err);
+        });
+    } else {
+      API.post(`/diary/like/22/1`)
+        .then(() => {
+          setlike(true);
+          setLikeCount(prev => (prev += 1));
+          console.log('좋아요');
+        })
+        .catch(err => console.log('like post error', err));
+    }
   };
+
+  useEffect(() => {
+    if (initLike) {
+      // 첫 렌더링 시, ture 누른 견적 있음. delete 가능
+      setlike(true);
+    } else {
+      // 첫 렌더링 시, false 한번도 누르지 않음 post 가능
+      setlike(false);
+    }
+  }, []);
 
   return (
     <>

--- a/grass-diary/src/main.jsx
+++ b/grass-diary/src/main.jsx
@@ -5,7 +5,5 @@ import router from './router';
 import '../src/styles/reset.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
+  <RouterProvider router={router} />,
 );

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -126,22 +126,15 @@ const Setting = id => {
   const [unmodifyModal, setUnmodifyModal] = useState(false);
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
   const [completeDeleteModal, setCompleteDeleteModal] = useState(false);
-  const createdDate = '24년 03월 12일'; // 임시 데이터
+  const createdDate = '24년 03월 14일'; // 임시 데이터
   const date = new Date();
   useEffect(() => {
     if (
+      // 당일 : 일기 수정 가능
       createdDate.slice(0, 2) === String(date.getFullYear()).slice(2, 4) &&
       createdDate.slice(5, 6) == date.getMonth() + 1 &&
       createdDate.slice(8, 10) == date.getDate()
     ) {
-      // 당일 : 일기 수정 가능
-      setModifiable(true);
-    } else if (
-      createdDate.slice(8, 10) == date.getDate() - 1 &&
-      date.getHours() < 6 &&
-      date.getMinutes() < 60
-    ) {
-      // 다음 날 새벽 5시 59분 전까지 : 일기 수정 가능
       setModifiable(true);
     } else {
       // 그 외 시간 : 수정 불가능
@@ -156,7 +149,7 @@ const Setting = id => {
       setUnmodifyModal(true);
       return;
     }
-    // 수정 가능할 때의 로직
+    // 일기 수정 가능 시,
   };
 
   const deleteDiary = () => {

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -122,12 +122,6 @@ const contentStyle = stylex.create({
 });
 
 const Setting = id => {
-  // const token = localStorage.getItem('accessToken');
-  // const config = {
-  //   headers: {
-  //     Authorization: `Bearer ${token}`,
-  //   },
-  // };
   const [modifiable, setModifiable] = useState(false);
   const [unmodifyModal, setUnmodifyModal] = useState(false);
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
@@ -160,11 +154,11 @@ const Setting = id => {
 
   const deleteDiary = async () => {
     await API.delete(`/diary/${id.id}`)
-      .then(res => {
-        console.log(res);
+      .then(() => {
+        console.log('삭제 완료');
         setCompleteDeleteModal(true);
       })
-      .catch(err => console.log('삭제 에러', err));
+      .catch(err => console.log('삭제 error', err));
   };
 
   return (

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 import testImg from '../../assets/icon/basicProfile.png';
@@ -121,7 +121,7 @@ const contentStyle = stylex.create({
   },
 });
 
-const Setting = id => {
+const Setting = ({ id, config }) => {
   const [modifiable, setModifiable] = useState(false);
   const [unmodifyModal, setUnmodifyModal] = useState(false);
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
@@ -152,7 +152,12 @@ const Setting = id => {
     // 일기 수정 가능 시,
   };
 
-  const deleteDiary = () => {
+  const deleteDiary = async () => {
+    const response = await axios.delete(
+      `http://localhost:8080/api/diary/${id}`,
+      config,
+    );
+    // console.log('삭제 response', response);
     setCompleteDeleteModal(true);
   };
 
@@ -179,6 +184,7 @@ const Setting = id => {
 
 const Diary = () => {
   const id = useParams().id;
+  const navigate = useNavigate();
   const [diary, setDiary] = useState({});
   const [profile, setProfile] = useState();
 
@@ -197,7 +203,7 @@ const Diary = () => {
           config,
         );
         setDiary(response.data);
-        console.log(response.data);
+        // console.log(response.data);
         const memberId = response.data.memberId;
         const responseMember = await axios.get(
           `http://localhost:8080/api/member/profile/${memberId}`,
@@ -205,7 +211,8 @@ const Diary = () => {
         );
         setProfile(responseMember.data);
       } catch (err) {
-        console.log('상세 페이지 Error >>', err);
+        // console.log('상세 페이지 Error >>', err);
+        navigate('/non-existent-page');
       }
     };
     fetchDiaryData();
@@ -234,7 +241,7 @@ const Diary = () => {
               {diary.isPrivate ? '비공개' : '공개'}
             </span>
             <div {...stylex.props(titleStyle.ellipsis)}>
-              <Setting id={id} />
+              <Setting id={id} config={config} />
             </div>
           </div>
         </div>

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -196,6 +196,10 @@ const Diary = () => {
   };
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [id]);
+
+  useEffect(() => {
     const fetchDiaryData = async () => {
       try {
         const response = await axios.get(

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
 
-import testImg from '../../assets/icon/profile.jpeg';
+import testImg from '../../assets/icon/basicProfile.png';
 import Header from '../../components/Header';
 import BackButton from '../../components/BackButton';
 import Like from '../../components/Like';
@@ -208,9 +208,10 @@ const Diary = () => {
     };
 
     axios
-      .get(`http://localhost:8080/api/${id}`, config)
+      .get(`http://localhost:8080/api/diary/${id}`, config)
       .then(response => {
         const diary = response.data;
+        console.log(diary);
         setDiary(diary);
       })
       .catch(error => {
@@ -225,13 +226,16 @@ const Diary = () => {
         {/* 일기 타이틀 */}
         <div>
           <div {...stylex.props(titleStyle.progileBox)}>
-            <img {...stylex.props(titleStyle.profileImg)} src={testImg}></img>
+            <img
+              {...stylex.props(titleStyle.profileImg)}
+              src={diary.hasImage ? null : testImg}
+            ></img>
             <div {...stylex.props(titleStyle.emoji)}>X</div>
             <div {...stylex.props(titleStyle.name)}>name</div>
           </div>
           <div {...stylex.props(titleStyle.diaryHeader)}>
-            <span {...stylex.props(titleStyle.title)}>title</span>
-            <span {...stylex.props(titleStyle.time)}>time</span>
+            <span {...stylex.props(titleStyle.title)}>{diary.createdDate}</span>
+            <span {...stylex.props(titleStyle.time)}>{diary.createdAt}</span>
             <span {...stylex.props(titleStyle.privateOrPubilc)}>
               {diary.isPrivate ? '비공개' : '공개'}
             </span>
@@ -243,7 +247,11 @@ const Diary = () => {
 
         {/* 일기 내용 */}
         <div {...stylex.props(contentStyle.diaryContent)}>
-          <div {...stylex.props(contentStyle.hashTag)}>hashtag</div>
+          <div {...stylex.props(contentStyle.hashTag)}>
+            {diary.tags?.map(tag => {
+              return `#${tag.tag} `;
+            })}
+          </div>
           <p {...stylex.props(contentStyle.content)}>{diary.content}</p>
         </div>
 

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -187,6 +187,7 @@ const Diary = () => {
   const navigate = useNavigate();
   const [diary, setDiary] = useState({});
   const [profile, setProfile] = useState();
+  const [likeCount, setLikeCount] = useState();
 
   const fetchDiaryData = async () => {
     try {
@@ -196,6 +197,7 @@ const Diary = () => {
 
       setDiary(response.data);
       setProfile(responseMember.data);
+      setLikeCount(response.data.likeCount);
     } catch (err) {
       console.log('상세 페이지 Error >>', err);
       navigate('/non-existent-page');
@@ -248,7 +250,7 @@ const Diary = () => {
 
         {/* 일기 하단 */}
         <div {...stylex.props(styles.diaryFooter)}>
-          <Like likeCount={diary.likeCount !== 0 ? diary.likeCount : null} />
+          <Like likeCount={likeCount} setLikeCount={setLikeCount} />
           <div {...stylex.props(styles.feelBackground)}>
             <div {...stylex.props(styles.feel)}></div>
           </div>

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -122,6 +122,12 @@ const contentStyle = stylex.create({
 });
 
 const Setting = id => {
+  // const token = localStorage.getItem('accessToken');
+  // const config = {
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // };
   const [modifiable, setModifiable] = useState(false);
   const [unmodifyModal, setUnmodifyModal] = useState(false);
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
@@ -153,8 +159,12 @@ const Setting = id => {
   };
 
   const deleteDiary = async () => {
-    await API.delete(`/diary/${id}`);
-    setCompleteDeleteModal(true);
+    await API.delete(`/diary/${id.id}`)
+      .then(res => {
+        console.log(res);
+        setCompleteDeleteModal(true);
+      })
+      .catch(err => console.log('삭제 에러', err));
   };
 
   return (

--- a/grass-diary/src/pages/Diary/NonExistentDiary.jsx
+++ b/grass-diary/src/pages/Diary/NonExistentDiary.jsx
@@ -1,10 +1,13 @@
 import * as stylex from '@stylexjs/stylex';
 import Header from '../../components/Header';
+import BackButton from '../../components/BackButton';
 
 const styles = stylex.create({
-  wrap: {},
+  wrap: {
+    padding: '65px 80px 0 80px',
+  },
   content: {
-    marginTop: '200px',
+    marginTop: '150px',
     textAlign: 'center',
     fontSize: '28px',
     fontWeight: '600',
@@ -15,7 +18,12 @@ const NonExistentDiary = () => {
   return (
     <>
       <Header />
-      <div {...stylex.props(styles.content)}>존재 하지 않는 일기입니다❗</div>
+      <div {...stylex.props(styles.wrap)}>
+        <BackButton />
+        <div {...stylex.props(styles.content)}>
+          <p>존재 하지 않는 일기입니다❗</p>
+        </div>
+      </div>
     </>
   );
 };

--- a/grass-diary/src/pages/Diary/NonExistentDiary.jsx
+++ b/grass-diary/src/pages/Diary/NonExistentDiary.jsx
@@ -1,0 +1,23 @@
+import * as stylex from '@stylexjs/stylex';
+import Header from '../../components/Header';
+
+const styles = stylex.create({
+  wrap: {},
+  content: {
+    marginTop: '200px',
+    textAlign: 'center',
+    fontSize: '28px',
+    fontWeight: '600',
+  },
+});
+
+const NonExistentDiary = () => {
+  return (
+    <>
+      <Header />
+      <div {...stylex.props(styles.content)}>존재 하지 않는 일기입니다❗</div>
+    </>
+  );
+};
+
+export default NonExistentDiary;

--- a/grass-diary/src/pages/Diary/modal/UnmodifyModal.jsx
+++ b/grass-diary/src/pages/Diary/modal/UnmodifyModal.jsx
@@ -56,7 +56,7 @@ const UnmodifyModal = ({ setter }) => {
           </span>
           <br />
           <span {...stylex.props(styles.ie)}>
-            일기는 당일 06:00부터 다음 날 05:59까지 수정 가능합니다.
+            일기는 당일 00:00부터 24:00전 까지 수정 가능합니다.
           </span>
         </div>
       </div>

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -175,7 +175,7 @@ const Share = () => {
           </div>
           <div {...stylex.props(styles.latestFeed)}>
             <Feed
-              link={'/diary/1'}
+              link={'/diary/32'}
               title={title}
               content={content}
               name={name}

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -175,12 +175,12 @@ const Share = () => {
           </div>
           <div {...stylex.props(styles.latestFeed)}>
             <Feed
-              link={'/diary/view'}
+              link={'/diary/1'}
               title={title}
               content={content}
               name={name}
             />
-            <Feed link={'/diary/view'} />
+            <Feed link={'/diary/1'} />
             <Feed link={'/diary/view'} />
             <Feed link={'/diary/view'} />
             <Feed link={'/diary/view'} />

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -4,7 +4,7 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import Slider from 'react-slick';
 import { Link } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 import testImg from '../../assets/icon/profile.jpeg';
 
@@ -104,16 +104,23 @@ const Feed = ({ likeCount, link, title, content, name }) => {
     </Link>
   );
 };
+const PauseOnHover = () => {
+  const token = localStorage.getItem('accessToken');
+  const config = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+  const [top10Datas, setTop10Datas] = useState();
 
-function PauseOnHover() {
   useEffect(() => {
     axios
-      .get('http://localhost:8080/api/diary/1')
+      .get('http://localhost:8080/api/shared/diaries/popular', config)
       .then(response => {
-        console.log(response);
+        setTop10Datas(response.data);
       })
       .catch(error => {
-        console.log('Error', error);
+        console.log('Share Top10 Error', error);
       });
   }, []);
 
@@ -126,34 +133,25 @@ function PauseOnHover() {
     autoplaySpeed: 2000,
     pauseOnHover: true,
   };
-  const name = '작성자';
-  const title = '일기 제목';
-  const content =
-    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil suscipit corporis quibusdam quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, nsecessitatibus quo.Lorem ipsum dolor sitamet consectetur adipisicing elit. Nihil suscipit corporis quibusdam  quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, elit.Nihil suscipit corporis quibusdam  quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, elit.';
-
   return (
     <div className="slider-container">
       <Slider {...settings}>
-        <Feed
-          likeCount={1}
-          link={'/diary/view'}
-          title={title}
-          content={content}
-          name={name}
-        />
-        <Feed likeCount={2} link={'/diary/view'} />
-        <Feed likeCount={3} link={'/diary/view'} />
-        <Feed likeCount={4} link={'/diary/view'} />
-        <Feed likeCount={5} link={'/diary/view'} />
-        <Feed likeCount={6} link={'/diary/view'} />
-        <Feed likeCount={7} link={'/diary/view'} />
-        <Feed likeCount={8} link={'/diary/view'} />
-        <Feed likeCount={9} link={'/diary/view'} />
-        <Feed likeCount={10} link={'/diary/view'} />
+        {top10Datas?.map(data => {
+          return (
+            <Feed
+              key={data.diaryId}
+              likeCount={data.diaryLikeCount}
+              link={`/diary/${data.diaryId}`}
+              title={data.createdAt}
+              content={data.diaryContent}
+              name={data.nickname}
+            />
+          );
+        })}
       </Slider>
     </div>
   );
-}
+};
 
 const Share = () => {
   const name = '작성자';
@@ -175,14 +173,14 @@ const Share = () => {
           </div>
           <div {...stylex.props(styles.latestFeed)}>
             <Feed
-              link={'/diary/32'}
+              link={'/diary/16'}
               title={title}
               content={content}
               name={name}
             />
-            <Feed link={'/diary/1'} />
-            <Feed link={'/diary/view'} />
-            <Feed link={'/diary/view'} />
+            <Feed link={'/diary/17'} />
+            <Feed link={'/diary/18'} />
+            <Feed link={'/diary/19'} />
             <Feed link={'/diary/view'} />
             <Feed link={'/diary/view'} />
             <Feed link={'/diary/view'} />

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -167,7 +167,9 @@ const Share = () => {
   };
   const [cursorId, setCursorId] = useState(922337203685477600);
   const [LatestDatas, setLatestDatas] = useState();
+
   useEffect(() => {
+    window.scrollTo(0, 0);
     axios
       .get(
         `http://localhost:8080/api/shared/diaries/latest?cursorId=${cursorId}&size=12`,

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -137,12 +137,17 @@ const PauseOnHover = () => {
     <div className="slider-container">
       <Slider {...settings}>
         {top10Datas?.map(data => {
+          const date = data.createdAt;
+          const title =
+            `${date.slice(2, 4)}년 ` +
+            `${date.slice(5, 7)}월 ` +
+            `${date.slice(8, 10)}일`;
           return (
             <Feed
               key={data.diaryId}
               likeCount={data.diaryLikeCount}
               link={`/diary/${data.diaryId}`}
-              title={data.createdAt}
+              title={title}
               content={data.diaryContent}
               name={data.nickname}
             />
@@ -192,12 +197,17 @@ const Share = () => {
           </div>
           <div {...stylex.props(styles.latestFeed)}>
             {LatestDatas?.map(data => {
+              const date = data.createdAt;
+              const title =
+                `${date.slice(2, 4)}년 ` +
+                `${date.slice(5, 7)}월 ` +
+                `${date.slice(8, 10)}일`;
               return (
                 <Feed
                   key={data.diaryId}
                   likeCount={data.diaryLikeCount}
                   link={`/diary/${data.diaryId}`}
-                  title={data.createdAt}
+                  title={title}
                   content={data.content}
                   name={data.nickname}
                 />

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -154,10 +154,29 @@ const PauseOnHover = () => {
 };
 
 const Share = () => {
-  const name = '작성자';
-  const title = '일기 제목';
-  const content =
-    'Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil suscipit corporis quibusdam quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, nsecessitatibus quo.Lorem ipsum dolor sitamet consectetur adipisicing elit. Nihil suscipit corporis quibusdam  quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, elit.Nihil suscipit corporis quibusdam  quas. Aspernatur aperiam aut aliquid maiores expedita repudiandae deleniti quisquam corrupti neque illo facilis, rerum voluptatum, elit.';
+  const token = localStorage.getItem('accessToken');
+  const config = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+  const [cursorId, setCursorId] = useState(922337203685477600);
+  const [LatestDatas, setLatestDatas] = useState();
+  useEffect(() => {
+    axios
+      .get(
+        `http://localhost:8080/api/shared/diaries/latest?cursorId=${cursorId}&size=12`,
+        config,
+      )
+      .then(response => {
+        setCursorId(response.data.diaries[11].diaryId);
+        setLatestDatas(response.data.diaries);
+      })
+      .catch(error => {
+        console.log('Share Latest Error', error);
+      });
+  }, []);
+
   return (
     <>
       <Header />
@@ -172,19 +191,18 @@ const Share = () => {
             우리들의 다채로운 하루를 들어보세요
           </div>
           <div {...stylex.props(styles.latestFeed)}>
-            <Feed
-              link={'/diary/16'}
-              title={title}
-              content={content}
-              name={name}
-            />
-            <Feed link={'/diary/17'} />
-            <Feed link={'/diary/18'} />
-            <Feed link={'/diary/19'} />
-            <Feed link={'/diary/view'} />
-            <Feed link={'/diary/view'} />
-            <Feed link={'/diary/view'} />
-            <Feed link={'/diary/view'} />
+            {LatestDatas?.map(data => {
+              return (
+                <Feed
+                  key={data.diaryId}
+                  likeCount={data.diaryLikeCount}
+                  link={`/diary/${data.diaryId}`}
+                  title={data.createdAt}
+                  content={data.content}
+                  name={data.nickname}
+                />
+              );
+            })}
           </div>
         </div>
       </div>

--- a/grass-diary/src/router.jsx
+++ b/grass-diary/src/router.jsx
@@ -26,11 +26,8 @@ const router = createBrowserRouter([
       { path: '/share', element: <Share /> },
       { path: '/setting', element: <Setting /> },
       { path: '/mypage', element: <MyPage /> },
+      { path: '/non-existent-page', element: <NonExistentDiary /> },
     ],
-  },
-  {
-    path: '/non-existent-page',
-    element: <NonExistentDiary />,
   },
 ]);
 

--- a/grass-diary/src/router.jsx
+++ b/grass-diary/src/router.jsx
@@ -6,6 +6,7 @@ import Diary from './pages/Diary/Diary';
 import Share from './pages/Share/Share';
 import Setting from './pages/Setting/Setting';
 import MyPage from './pages/MyPage/MyPage';
+import NonExistentDiary from './pages/Diary/NonExistentDiary';
 
 const router = createBrowserRouter([
   {
@@ -35,6 +36,10 @@ const router = createBrowserRouter([
   {
     path: '/mypage',
     element: <MyPage />,
+  },
+  {
+    path: '/non-existent-page',
+    element: <NonExistentDiary />,
   },
 ]);
 


### PR DESCRIPTION
# 상세 페이지 api 요청
`api` /api/diary/{id}
### [GET] 일기 상세 내용
-  작성자 이름
- 프로필 사진
- 제목( 날짜)
- 작성된 시간
- 비공개/공개 여부 
- 일기 내용
- 좋아요 개수 ( 0일 경우 보이지 않도록 설정)
### [DELETE] 일기 삭제
- 삭제 된 후에 혹시라도 해당 페이지로 다시 렌더링 될 경우, `존재하지 않는 일기입니다` 알려주는 페이지로 이동.

# 공유페이지 api 요청
#### 불러오는 일기 피드 내용
- 프로필 사진
- 작성자 이름
- 일기 제목(작성된 날짜)
- 일기 내용( 350자가 넘어가면 ... 으로 처리)
- 좋아요 개수
### [GET]  Top 10 일기
`api` /api/shared/diaries/popular
이번주 기준 좋아요를 많이 받은 순으로 10개의 일기 불러오기 완료.
###  [GET] 최신 순 일기 
`api`  /api/shared/diaries/latest
최근 순으로 일기 불러오기 완료 

# 최신 순 일기 무한스크롤 구현하기
무한스크롤로 구현하는 방법은 2가지가 있습니다.
1. Scroll Event
    Scroll 이벤트를 감지하여 api를 요청하는 방법.    
    계속 감지해야하기 때문에 성능 저하 문제가 발생합니다 
    → `debounce` 나 `throttle` 를 적용해 개선 가능합니다. 
2. Intersection Observer Api 
    브라우저의 뷰포트와 설정한 요소의 교차점을 관찰해 요소가 뷰포트에 포함되는지 아닌지 구별하는 기능을 제공합니다. 
    **비동기적으로 실행**되기 때문에 scroll 이벤트 기반의 요소 관찰에서 발생하는 렌더링 성능이나 이벤트 연속 호출같은 문제 없이 사용할 수 있습니다.
   
'잔디 일기'에서는  `IntersectionObserver Api`를 사용하여 무한 스크롤을 구현했습니다.
데이터가 많지 않아 일기 3개 씩 불러오도록 설정해두었습니다.

구현 시 참고한 블로그입니다!
[블로그1](https://velog.io/@yj0509_11/react-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4Intersection-Observer-useEffect%EB%A1%9C-%EA%B5%AC%ED%98%84-9x4vf3uq), [블로그2](https://heropy.blog/2019/10/27/intersection-observer/)


 

 