### PR TITLE
🔨 fix: 로그인 미완료 사용자의 페이지 접근 제한 버그 수정 (CLIENT-78)

### DIFF
--- a/grass-diary/src/components/ProtectedRoute.jsx
+++ b/grass-diary/src/components/ProtectedRoute.jsx
@@ -1,9 +1,12 @@
 import { Outlet, Navigate } from 'react-router-dom';
-import { checkAuth } from '../utils/authUtils';
+import { useAuth } from '../hooks/useAuth';
 
 const ProtectedRoute = () => {
-  const isAthenticated = checkAuth();
-  return isAthenticated ? <Outlet /> : <Navigate to="/" />;
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return isAuthenticated ? <Outlet /> : <Navigate to="/" />;
 };
 
 export default ProtectedRoute;

--- a/grass-diary/src/hooks/useAuth.js
+++ b/grass-diary/src/hooks/useAuth.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+import { checkAuth } from '../utils/authUtils';
+
+export const useAuth = () => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loggedIn = async () => {
+      try {
+        const isLoggedIn = await checkAuth();
+        setIsAuthenticated(isLoggedIn);
+        setIsLoading(false);
+      } catch (error) {
+        console.error(`로그인되지 않은 사용자입니다. ${error}`);
+      }
+    };
+
+    loggedIn();
+  }, []);
+
+  return { isAuthenticated, isLoading };
+};


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 로그인을 하지 않은 사용자가 /main 페이지를 제외한 다른 페이지에 접근했을 때, 제한되지 않고 이동이 가능합니다. 따라서 접근 제한 로직에 대한 수정이 필요합니다.

## 🔨 TO-BE

- [x] 로그인 미완료 사용자의 페이지 접근 제한 버그 수정
  - [x] useAuth custom hook 구현 (사용자의 로그인 여부 판단해 주는 hook)
  - [x] Loading 상태 임시 구현 