### PR TITLE
:sparkles: feat: 사용자 고유 아이디 조회 custom hook 구현 및 적용

### DIFF
--- a/grass-diary/src/hooks/useUser.js
+++ b/grass-diary/src/hooks/useUser.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import API from '../services/index';
+
+const useUser = () => {
+  const [memberId, setMemberId] = useState(null);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        API.get('/me').then(response => {
+          setMemberId(response.data.memberId);
+        });
+      } catch (error) {
+        console.error(`사용자 정보 조회가 불가능합니다. ${error}`);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  return memberId;
+};
+
+export default useUser;

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -9,6 +9,7 @@ import SimpleSlider from './CardSlider';
 import Swal from 'sweetalert2';
 import dayjs from 'dayjs';
 import { checkAuth } from '../../utils/authUtils';
+import useUser from '../../hooks/useUser';
 
 const styles = stylex.create({
   title: {
@@ -390,6 +391,7 @@ const MiddleSection = () => {
   const [rewardPoint, setRewardPoint] = useState(null);
   const [grassCount, setGrassCount] = useState(null);
   const [grassColor, setGrassColor] = useState(null);
+
   const currentDate = dayjs();
   const currentMonth = currentDate.format('M');
   const temporaryPoint = grassCount * 10;
@@ -421,15 +423,19 @@ const MiddleSection = () => {
     }
   });
 
+  const memberId = useUser();
+
   useEffect(() => {
-    API.get('/member/totalReward/1')
-      .then(response => {
-        setRewardPoint(response.data.rewardPoint);
-      })
-      .catch(error => {
-        console.log('Error', error);
-      });
-  }, []);
+    if (memberId) {
+      API.get(`/member/totalReward/${memberId}`)
+        .then(response => {
+          setRewardPoint(response.data.rewardPoint);
+        })
+        .catch(error => {
+          console.error('Error', error);
+        });
+    }
+  }, [memberId]);
 
   // useEffect(() => {
   //   API.get('/main/grass/1')

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -7,6 +7,7 @@ import Button from '../../components/Button';
 import diaryImage from '../../assets/icon/diaryImage.png';
 import basicProfile from '../../assets/icon/basicProfile.png';
 import API from '../../services';
+import useUser from '../../hooks/useUser';
 
 const Container = ({ children }) => {
   return <div {...stylex.props(styles.container)}>{children}</div>;
@@ -62,16 +63,19 @@ const ToggleButton = ({ buttonLabel, handleToggleButton }) => {
 
 const Profile = () => {
   const [profile, setProfile] = useState([]);
+  const memberId = useUser();
 
   useEffect(() => {
-    API.get('/member/profile/1')
-      .then(response => {
-        setProfile(response.data);
-      })
-      .catch(error => {
-        console.log(error);
-      });
-  });
+    if (memberId) {
+      API.get(`/member/profile/${memberId}`)
+        .then(response => {
+          setProfile(response.data);
+        })
+        .catch(error => {
+          console.error(`사용자 프로필을 조회할 수 없습니다. ${error}`);
+        });
+    }
+  }, [memberId]);
 
   return (
     <div {...stylex.props(styles.profileDetails)}>
@@ -174,6 +178,7 @@ const SearchBar = () => {
 const Diary = () => {
   const [diaryList, setDiaryList] = useState([]);
   const [mood, setMood] = useState([]);
+  const memberId = useUser();
 
   const emoji = [
     ['🤯', '🤬', '😭'],
@@ -188,14 +193,16 @@ const Diary = () => {
   ];
 
   useEffect(() => {
-    API.get(`/diary/main/1`)
-      .then(response => {
-        setDiaryList(response.data.content);
-      })
-      .catch(error => {
-        console.log('Error', error);
-      });
-  }, []);
+    if (memberId) {
+      API.get(`/diary/main/${memberId}`)
+        .then(response => {
+          setDiaryList(response.data.content);
+        })
+        .catch(error => {
+          console.log(`사용자의 일기를 조회할 수 없습니다. ${error}`);
+        });
+    }
+  }, [memberId]);
 
   useMemo(() => {
     const moods = [];


### PR DESCRIPTION
## 사용자 고유 아이디 조회 custom hook 구현 및 적용 (CLIENT-80)

### 🔎 AS-IS

- 현재 사용자의 고유 아이디를 조회 가능한 API를 사용하고 있지 않습니다. 많은 요청에서 사용 가능해야 하므로, 중복 가능성을 고려해 사용자의 고유 아이디를 조회할 수 있는 요청을 custom hook으로 구현해야 합니다.

### ✨ TO-BE

- [x] 사용자의 고유 아이디를 조회할 수 있는 custom hook을 구현 및 적용한다. 