### PR TITLE
:sparkles: feat: 사용자 로그아웃 구현

### DIFF
--- a/grass-diary/src/components/Header.jsx
+++ b/grass-diary/src/components/Header.jsx
@@ -1,9 +1,10 @@
 import * as stylex from '@stylexjs/stylex';
 import testImg from '../assets/icon/profile.jpeg';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import useUser from '../hooks/useUser';
 import API from '../services';
+import { clearAuth } from '../utils/authUtils';
 
 const header = stylex.create({
   container: {
@@ -78,6 +79,13 @@ const menuBar = stylex.create({
 });
 
 const MenuBar = ({ toggle, headerRef }) => {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    clearAuth();
+    navigate('/');
+  };
+
   return (
     <div
       ref={headerRef}
@@ -95,12 +103,10 @@ const MenuBar = ({ toggle, headerRef }) => {
           <span {...stylex.props(menuBar.span)}>설정</span>
         </div>
       </Link>
-      <Link to="/">
-        <div {...stylex.props(menuBar.box)}>
-          <i className="fa-solid fa-arrow-right-from-bracket"></i>
-          <span {...stylex.props(menuBar.span)}>로그아웃</span>
-        </div>
-      </Link>
+      <div {...stylex.props(menuBar.box)} onClick={handleLogout}>
+        <i className="fa-solid fa-arrow-right-from-bracket"></i>
+        <span {...stylex.props(menuBar.span)}>로그아웃</span>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 사용자 로그아웃 구현 (CLIENT-96)

### 🔎 AS-IS

- 현재 헤더 메뉴바 내에 있는 로그아웃 버튼을 클릭했을 때, 인트로 페이지로 이동하고 있지만 이에 대응하는 로그아웃 기능은 구현되어 있지 않습니다. 때문에 사용자가 서비스에서 로그아웃할 수 있도록 기능 구현이 필요합니다. 

### ✨ TO-BE

- [x] 사용자가 헤더 메뉴바의 로그아웃 버튼을 클릭할 경우 로그아웃된다.
- [x] 로그아웃이 완료될 경우 인트로 페이지로 이동한다.