### PR TITLE
:sparkles: feat: 설정 페이지 사용자 정보 수정 구현

### DIFF
--- a/grass-diary/src/components/Button.jsx
+++ b/grass-diary/src/components/Button.jsx
@@ -1,8 +1,7 @@
 import stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  startButton: (width, color, backgroundColor, border) => ({
-    marginTop: '25px',
+  startButton: (width, height, color, backgroundColor, border, marginTop) => ({
     padding: '12px 10px 12px 10px',
 
     borderRadius: '30px',
@@ -11,19 +10,37 @@ const styles = stylex.create({
     cursor: 'pointer',
 
     width,
+    height,
     color,
     border,
     backgroundColor,
+    marginTop,
   }),
 });
 
-const Button = ({ text, onClick, width, color, backgroundColor, border }) => {
+const Button = ({
+  text,
+  onClick,
+  width,
+  height,
+  color,
+  backgroundColor,
+  border,
+  marginTop,
+}) => {
   return (
     <>
       <button
         onClick={onClick}
         {...stylex.props(
-          styles.startButton(width, color, backgroundColor, border),
+          styles.startButton(
+            width,
+            height,
+            color,
+            backgroundColor,
+            border,
+            marginTop,
+          ),
         )}
       >
         {text}

--- a/grass-diary/src/components/Header.jsx
+++ b/grass-diary/src/components/Header.jsx
@@ -1,5 +1,4 @@
 import * as stylex from '@stylexjs/stylex';
-import testImg from '../assets/icon/profile.jpeg';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import Profile from './Profile';

--- a/grass-diary/src/components/Profile.jsx
+++ b/grass-diary/src/components/Profile.jsx
@@ -12,12 +12,12 @@ const styles = stylex.create({
 });
 
 const Profile = ({ width, height }) => {
-  const userProfile = useProfile().profileImageURL;
+  const { profileImage } = useProfile();
 
   return (
     <img
       {...stylex.props(styles.profileImage(width, height))}
-      src={userProfile}
+      src={profileImage}
       alt="사용자 프로필 사진"
     />
   );

--- a/grass-diary/src/hooks/useProfile.js
+++ b/grass-diary/src/hooks/useProfile.js
@@ -3,14 +3,22 @@ import useUser from './useUser';
 import API from '../services';
 
 const useProfile = () => {
-  const [profile, setProfile] = useState([]);
   const memberId = useUser();
+  const [profileImage, setProfileImage] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [profileIntro, setProfileIntro] = useState('');
 
   useEffect(() => {
     if (memberId) {
       API.get(`/member/profile/${memberId}`)
         .then(response => {
-          setProfile(response.data);
+          const profileImageURL = response.data.profileImageURL;
+          const ninkName = response.data.nickName;
+          const intro = response.data.profileIntro;
+
+          setProfileImage(profileImageURL);
+          setNickname(ninkName);
+          setProfileIntro(intro);
         })
         .catch(error => {
           console.error(`사용자 프로필을 조회할 수 없습니다. ${error}`);
@@ -18,7 +26,7 @@ const useProfile = () => {
     }
   }, [memberId]);
 
-  return profile;
+  return { profileImage, nickname, setNickname, profileIntro, setProfileIntro };
 };
 
 export default useProfile;

--- a/grass-diary/src/pages/Intro/introComponents.jsx
+++ b/grass-diary/src/pages/Intro/introComponents.jsx
@@ -47,6 +47,7 @@ const OpenModalButton = () => {
         color="#FFF"
         backgroundColor="#28CA3B"
         border="none"
+        marginTop="20px"
       />
       {!isLoggedIn && isModalOpen && (
         <LoginModal isOpen={handleOpenModal} isClose={handleCloseModal} />

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -77,6 +77,7 @@ const ProfileImage = () => {
             color="#000"
             backgroundColor="#FFFFFF"
             border="2px solid #929292"
+            marginTop="25px"
           />
         </div>
       </div>

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -64,7 +64,7 @@ const ToggleButton = ({ buttonLabel, handleToggleButton }) => {
 };
 
 const ProfileImage = () => {
-  const profile = useProfile();
+  const { nickname, profileIntro } = useProfile();
 
   return (
     <div {...stylex.props(styles.profileDetails)}>
@@ -83,15 +83,11 @@ const ProfileImage = () => {
       </div>
       <div {...stylex.props(styles.profileRight)}>
         <div {...stylex.props(styles.nameSection)}>
-          <span>{profile.nickName}</span>
+          <span>{nickname}</span>
         </div>
         <Grass />
         <div>
-          <span>
-            {profile.profileIntro !== null
-              ? profile.profileIntro
-              : '소개글입니다.'}
-          </span>
+          <span>{profileIntro !== null ? profileIntro : '소개글입니다.'}</span>
         </div>
       </div>
     </div>

--- a/grass-diary/src/pages/Setting/Setting.jsx
+++ b/grass-diary/src/pages/Setting/Setting.jsx
@@ -3,17 +3,56 @@ import Header from '../../components/Header';
 import Profile from '../../components/Profile';
 import Button from '../../components/Button';
 import styles from './styles';
+import API from '../../services';
+import { useState, useEffect } from 'react';
+import useProfile from '../../hooks/useProfile';
 
 const SettingSection = ({ children, label }) => {
   return (
-    <div {...stylex.props(styles.settingSection)}>
+    <form {...stylex.props(styles.settingSection)}>
       <span>{label}</span>
       {children}
-    </div>
+    </form>
   );
 };
 
 const Setting = () => {
+  const { nickname, setNickname, profileIntro, setProfileIntro } = useProfile();
+  const [clickedNameSave, setClickedNameSave] = useState(false);
+  const [clickedIntroSave, setClickedIntroSave] = useState(false);
+
+  const handleChange = setter => event => {
+    setter(event.target.value);
+  };
+
+  const handleClick = setter => () => {
+    setter(true);
+  };
+
+  useEffect(() => {
+    if (clickedNameSave) {
+      API.patch('/members/me', { nickname: nickname })
+        .then(() => {
+          setClickedNameSave(false);
+        })
+        .catch(error => {
+          console.error(`사용자 정보를 수정할 수 없습니다. ${error}`);
+        });
+    }
+  }, [clickedNameSave, nickname]);
+
+  useEffect(() => {
+    if (clickedIntroSave) {
+      API.patch('/members/me', { profileIntro: profileIntro })
+        .then(() => {
+          setClickedIntroSave(false);
+        })
+        .catch(error => {
+          console.error(`사용자 정보를 수정할 수 없습니다. ${error}`);
+        });
+    }
+  }, [clickedIntroSave, profileIntro]);
+
   return (
     <div {...stylex.props(styles.container)}>
       <Header />
@@ -37,7 +76,8 @@ const Setting = () => {
             <SettingSection label="닉네임">
               <input
                 {...stylex.props(styles.textInput('0 0 0 1.25rem', '3.2rem'))}
-                placeholder="닉네임"
+                placeholder={nickname}
+                onChange={handleChange(setNickname)}
               ></input>
               <Button
                 text="저장"
@@ -45,12 +85,14 @@ const Setting = () => {
                 color="#000"
                 backgroundColor="#FFF"
                 border="2px solid #929292"
+                onClick={handleClick(setClickedNameSave)}
               />
             </SettingSection>
             <SettingSection label="소개글">
               <textarea
                 {...stylex.props(styles.textInput('1rem 1.25rem', '6.25rem'))}
-                placeholder="소개글을 입력해 주세요."
+                placeholder={profileIntro}
+                onChange={handleChange(setProfileIntro)}
               ></textarea>
               <Button
                 text="저장"
@@ -59,6 +101,7 @@ const Setting = () => {
                 color="#000"
                 backgroundColor="#FFF"
                 border="2px solid #929292"
+                onClick={handleClick(setClickedIntroSave)}
               />
             </SettingSection>
             <SettingSection label="잔디색">

--- a/grass-diary/src/pages/Setting/Setting.jsx
+++ b/grass-diary/src/pages/Setting/Setting.jsx
@@ -28,8 +28,9 @@ const Setting = () => {
               text="프로필 사진 변경"
               width="9.4rem"
               color="#000"
-              backgroundColor="#FFFFFF"
+              backgroundColor="#FFF"
               border="2px solid #929292"
+              marginTop="25px"
             />
           </div>
           <div {...stylex.props(styles.profileRight)}>
@@ -38,12 +39,27 @@ const Setting = () => {
                 {...stylex.props(styles.textInput('0 0 0 1.25rem', '3.2rem'))}
                 placeholder="닉네임"
               ></input>
+              <Button
+                text="저장"
+                width="70px"
+                color="#000"
+                backgroundColor="#FFF"
+                border="2px solid #929292"
+              />
             </SettingSection>
             <SettingSection label="소개글">
               <textarea
                 {...stylex.props(styles.textInput('1rem 1.25rem', '6.25rem'))}
                 placeholder="소개글을 입력해 주세요."
               ></textarea>
+              <Button
+                text="저장"
+                width="70px"
+                height="51px"
+                color="#000"
+                backgroundColor="#FFF"
+                border="2px solid #929292"
+              />
             </SettingSection>
             <SettingSection label="잔디색">
               <div {...stylex.props(styles.colorWrapper)}>

--- a/grass-diary/src/pages/Setting/styles.js
+++ b/grass-diary/src/pages/Setting/styles.js
@@ -61,7 +61,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     justifyContent: 'center',
 
-    width: '50%',
+    width: '55%',
     gap: '1.25rem',
   },
 


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 설정 페이지에서 닉네임 및 소개글을 수정해도, 모든 페이지에 수정 사항이 적용되고 있지 않습니다. 따라서 설정 페이지에서 사용자가 정보를 변경할 수 있도록 구현해야 합니다.

## ✨ TO-BE

- [x] 사용자가 닉네임을 입력한 뒤 저장 버튼을 클릭하면 수정된 닉네임이 적용된다.
  - [x] 이때, input의 `placeholder`는 현재 닉네임으로 설정한다. 
- [x] 사용자가 소개글을 입력한 뒤 저장 버튼을 클릭하면 수정된 소개글이 적용된다.
  - [x] 이때, textarea의 `placeholder`는 현재 소개글으로 설정한다.
  - [x] 소개글의 값이 `null`인 경우에는 `소개글입니다.` 문구를 표시한다.
  
## 🖥️ 구현 화면

### 초기 설정 화면

<img width="982" alt="스크린샷 2024-03-29 오전 11 25 58" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/dccbd2d7-86a0-45df-a5c1-c7de6bd61c78">

### 닉네임 수정

<img width="995" alt="스크린샷 2024-03-29 오전 11 26 38" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/d6c1c2d4-97bc-4f12-ad0d-bffd4c974af7">

### 소개글 수정

<img width="995" alt="스크린샷 2024-03-29 오전 11 26 59" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/62a4d4a0-45fb-4d69-b234-2009211984aa">

### 수정 완료된 이후 placeholder

<img width="995" alt="스크린샷 2024-03-29 오전 11 27 07" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/288c4a52-226a-484c-890b-1cb92143a92a">

### 마이 페이지에 적용된 프로필 수정 사항

<img width="995" alt="스크린샷 2024-03-29 오전 11 27 30" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/89cf662d-96e8-48f9-b347-cc0d65a901da">
