### PR TITLE
:sparkles: feat: 일기 클릭 시 상세 일기 페이지로 이동

### DIFF
--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import API from '../../services';
 import Like from '../../components/Like';
 import Button from '../../components/Button';
-import diaryImage from '../../assets/icon/diaryImage.png';
+import { Link } from 'react-router-dom';
 import MoodProfile from '../../components/MoodProfile';
 import Profile from '../../components/Profile';
 import useUser from '../../hooks/useUser';
@@ -173,27 +173,31 @@ const Diary = () => {
   return (
     <div {...stylex.props(styles.diaryList)}>
       {diaryList.map((diary, index) => (
-        <div {...stylex.props(styles.diary)} key={index}>
-          <div {...stylex.props(styles.smallProfileSection)}>
-            <MoodProfile diary={diaryList} index={index} />
-            <div {...stylex.props(styles.smallDetailes)}>
-              <span {...stylex.props(styles.name)}>{diary.createdDate}</span>
-              <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
+        <Link key={diary.diaryId} to={`/diary/${diary.diaryId}`}>
+          <div {...stylex.props(styles.diary)} key={diary.diaryId}>
+            <div {...stylex.props(styles.smallProfileSection)}>
+              <MoodProfile diary={diaryList} index={index} />
+              <div {...stylex.props(styles.smallDetailes)}>
+                <span {...stylex.props(styles.name)}>{diary.createdDate}</span>
+                <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
+              </div>
+            </div>
+            <div {...stylex.props(styles.diaryContent)}>
+              <div>
+                {diary.tags.map(tag => (
+                  <span {...stylex.props(styles.hashtag)} key={tag.id}>
+                    #{`${tag.tag} `}
+                  </span>
+                ))}
+              </div>
+              <span>{diary.content}</span>
+            </div>
+            <div {...stylex.props(styles.likeSection)}>
+              <Like />
+              <span>{diary.likeCount}</span>
             </div>
           </div>
-          <div {...stylex.props(styles.diaryContent)}>
-            {diary.tags.map(tag => (
-              <span {...stylex.props(styles.hashtag)} key={tag.id}>
-                #{tag.tag}
-              </span>
-            ))}
-            <span>{diary.content}</span>
-          </div>
-          <div {...stylex.props(styles.likeSection)}>
-            <Like />
-            <span>{diary.likeCount}</span>
-          </div>
-        </div>
+        </Link>
       ))}
     </div>
   );


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 마이 페이지에 나타나는 일기를 클릭했을 때 상세 페이지가 나타나고 있지 않습니다. 따라서 일기 클릭 시 해당하는 일기의 상세 페이지로 이동할 수 있어야 합니다.

## ✨ TO-BE

- [x] 마이페이지의 일기 클릭 시 해당하는 일기의 상세 페이지로 이동한다.

![일기 상세 페이지 이동](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/3a58f83e-5556-47ed-a19f-702a8b429418)
