### PR TITLE
:sparkles: feat: 마이 페이지 일기 검색 기능 구현 (CLIENT-74)

### DIFF
--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -17,9 +17,14 @@ const Container = ({ children }) => {
 
 const MainContainer = () => {
   const [toggleButton, setToggleButton] = useState('나의 일기장');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const handleToggleButton = buttonName => {
     setToggleButton(buttonName);
+  };
+
+  const handleSearchChange = event => {
+    setSearchTerm(event.target.value);
   };
 
   return (
@@ -32,9 +37,9 @@ const MainContainer = () => {
         />
       </div>
       <div {...stylex.props(styles.mainSection)}>
-        <SearchBar />
+        <SearchBar onSearchChange={handleSearchChange} />
         {toggleButton === '나의 일기장' ? (
-          <Diary />
+          <Diary searchTerm={searchTerm} />
         ) : (
           <p>현재 교환 일기가 없습니다.</p>
         )}
@@ -140,7 +145,7 @@ const Grass = () => {
   );
 };
 
-const SearchBar = () => {
+const SearchBar = ({ onSearchChange }) => {
   return (
     <div {...stylex.props(styles.searchSection)}>
       <div {...stylex.props(styles.searchIcon)}>
@@ -149,12 +154,13 @@ const SearchBar = () => {
       <input
         {...stylex.props(styles.searchBar)}
         placeholder="일기 검색하기"
+        onChange={onSearchChange}
       ></input>
     </div>
   );
 };
 
-const Diary = () => {
+const Diary = ({ searchTerm }) => {
   const [diaryList, setDiaryList] = useState([]);
   const memberId = useUser();
 
@@ -170,9 +176,13 @@ const Diary = () => {
     }
   }, [memberId]);
 
+  const filterDiaryList = diaryList.filter(diary =>
+    diary.content.includes(searchTerm),
+  );
+
   return (
     <div {...stylex.props(styles.diaryList)}>
-      {diaryList.map((diary, index) => (
+      {filterDiaryList.map((diary, index) => (
         <Link key={diary.diaryId} to={`/diary/${diary.diaryId}`}>
           <div {...stylex.props(styles.diary)} key={diary.diaryId}>
             <div {...stylex.props(styles.smallProfileSection)}>

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -161,8 +161,10 @@ const styles = stylex.create({
     flexDirection: 'column',
 
     width: '100%',
-    paddingBottom: '50px',
+    minHeight: '1000px',
 
+    paddingBottom: '50px',
+    overflowY: 'auto',
     gap: '50px',
   },
 


### PR DESCRIPTION
## 마이 페이지 일기 검색 기능 구현 (CLIENT-74)

### 🔎 AS-IS

- 현재 마이페이지의 검색 기능이 구현되어 있지 않아 일기 내용 검색을 위한 검색 기능 구현이 필요합니다.

### ✨ TO-BE

- [x] 사용자가 검색 내용을 검색창에 입력할 시 해당 내용이 포함되어 있는 일기가 나타난다.

![검색](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/e81105d1-5d4a-40b8-b123-5d9d5109242b)
