### PR TITLE
:sparkles: feat: 마이 페이지 일기 날짜 순 정렬 구현 (CLIENT-65)

### DIFF
--- a/grass-diary/src/components/Ellipsis.jsx
+++ b/grass-diary/src/components/Ellipsis.jsx
@@ -28,6 +28,11 @@ const ellipsis = stylex.create({
       default: '1px solid #BFBFBF',
       ':last-child': 'none',
     },
+    cursor: 'pointer',
+    color: {
+      default: '#000',
+      ':hover': '#BFBFBF',
+    },
   },
 });
 

--- a/grass-diary/src/components/Ellipsis.jsx
+++ b/grass-diary/src/components/Ellipsis.jsx
@@ -10,10 +10,10 @@ const ellipsis = stylex.create({
     position: 'relative',
     cursor: 'pointer',
   },
-  container: translateValue => ({
+  container: (width, translateValue) => ({
     position: 'absolute',
     top: '-8px',
-    width: '136px',
+    width: `${width}px`,
     border: '1px solid #BFBFBF',
     borderRadius: '20px',
     backgroundColor: '#ffffff',
@@ -39,7 +39,7 @@ const EllipsisBox = ({ onClick, text }) => {
   );
 };
 
-const EllipsisIcon = ({ children, translateValue }) => {
+const EllipsisIcon = ({ children, width, translateValue }) => {
   const [open, setOpen] = useState(false);
   const ellisisRef = useRef(null);
   const iconRef = useRef(null);
@@ -72,7 +72,7 @@ const EllipsisIcon = ({ children, translateValue }) => {
       {open && (
         <div
           ref={ellisisRef}
-          {...stylex.props(ellipsis.container(translateValue))}
+          {...stylex.props(ellipsis.container(width, translateValue))}
         >
           <div {...stylex.props(ellipsis.box)}></div>
           {children}

--- a/grass-diary/src/pages/Diary/Setting.jsx
+++ b/grass-diary/src/pages/Diary/Setting.jsx
@@ -48,9 +48,9 @@ const Setting = id => {
 
   return (
     <>
-      <EllipsisIcon translateValue={'115px'}>
-        <EllipsisBox onClick={linkToModify} text={'수정'} />
-        <EllipsisBox onClick={showConfirmModal} text={'삭제'} />
+      <EllipsisIcon width="136" translateValue="115px">
+        <EllipsisBox onClick={linkToModify} text="수정" />
+        <EllipsisBox onClick={showConfirmModal} text="삭제" />
       </EllipsisIcon>
 
       {unmodifyModal && <UnmodifyModal setter={setUnmodifyModal} />}

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import API from '../../services';
 import Like from '../../components/Like';
 import Button from '../../components/Button';
+import { EllipsisBox, EllipsisIcon } from '../../components/Ellipsis';
 import { Link } from 'react-router-dom';
 import MoodProfile from '../../components/MoodProfile';
 import Profile from '../../components/Profile';
@@ -38,6 +39,7 @@ const MainContainer = () => {
       </div>
       <div {...stylex.props(styles.mainSection)}>
         <SearchBar onSearchChange={handleSearchChange} />
+        <SortButton />
         {toggleButton === '나의 일기장' ? (
           <Diary searchTerm={searchTerm} />
         ) : (
@@ -156,6 +158,17 @@ const SearchBar = ({ onSearchChange }) => {
         placeholder="일기 검색하기"
         onChange={onSearchChange}
       ></input>
+    </div>
+  );
+};
+
+const SortButton = () => {
+  return (
+    <div {...stylex.props(styles.sortContainer)}>
+      <EllipsisIcon width="160" translateValue="135px">
+        <EllipsisBox onClick="" text="최신 순으로 보기" />
+        <EllipsisBox onClick="" text="오래된 순으로 보기" />
+      </EllipsisIcon>
     </div>
   );
 };

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -129,14 +129,13 @@ const styles = stylex.create({
     alignItems: 'center',
 
     width: '70%',
-    gap: '50px',
+    gap: '20px',
   },
 
   searchSection: {
     display: 'flex',
 
     width: '100%',
-
     padding: '15px 20px 15px 20px',
 
     borderRadius: '30px',
@@ -154,6 +153,13 @@ const styles = stylex.create({
 
     border: 'none',
     outline: 'none',
+  },
+
+  sortContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+
+    width: '95%',
   },
 
   diaryList: {


### PR DESCRIPTION
## 마이 페이지 일기 날짜 순 정렬 구현 (CLIENT-65)

### 🔎 AS-IS

- 현재 사용자의 모든 일기가 최신 순으로만 정렬 가능하도록 구현되어 있습니다. 따라서 사용자가 정렬 순서를 선택할 수 있도록 추가적인 기능 구현이 필요합니다.

### ✨ TO-BE

- [x] 검색창 하단에 정렬 순서를 선택할 수 있는 Ellipsis component를 추가한다.
- [x] 사용자가 최신 순으로 보기를 선택할 경우 날짜가 최신인 일기부터 나타난다. (default: latest)
- [x] 사용자가 오래된 순으로 보기를 선택할 경우 날짜가 오래된 일기부터 나타난다.

![정렬](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/cc1acbed-e94a-4c2a-857f-ec9de48c4a8d)
 
