### PR TITLE
:sparkles: feat: 마이 페이지 일기 목록 페이지 버튼 구현 (CLIENT-98)

### DIFF
--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -195,11 +195,13 @@ const SortButton = ({ onSortChange }) => {
 };
 
 const Diary = ({ searchTerm, sortOrder }) => {
-  const [diaryList, setDiaryList] = useState([]);
   const memberId = useUser();
+  const [diaryList, setDiaryList] = useState([]);
+  const [pageSize, setPageSize] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
 
   useEffect(() => {
-    let apiUrl = `/diary/main/${memberId}?page=0`;
+    let apiUrl = `/diary/main/${memberId}?page=${currentPage}`;
     if (sortOrder === 'oldest') {
       apiUrl += `&sort=createdAt,ASC`;
     }
@@ -207,48 +209,64 @@ const Diary = ({ searchTerm, sortOrder }) => {
     if (memberId) {
       API.get(apiUrl)
         .then(response => {
+          setPageSize(response.data.totalPages);
           setDiaryList(response.data.content);
         })
         .catch(error => {
           console.log(`사용자의 일기를 조회할 수 없습니다. ${error}`);
         });
     }
-  }, [memberId, sortOrder]);
+  }, [memberId, sortOrder, currentPage]);
 
   const filterDiaryList = diaryList.filter(diary =>
     diary.content.includes(searchTerm),
   );
 
+  const handlePageChange = page => {
+    setCurrentPage(page);
+  };
+
   return (
-    <div {...stylex.props(styles.diaryList)}>
-      {filterDiaryList.map((diary, index) => (
-        <Link key={diary.diaryId} to={`/diary/${diary.diaryId}`}>
-          <div {...stylex.props(styles.diary)} key={diary.diaryId}>
-            <div {...stylex.props(styles.smallProfileSection)}>
-              <MoodProfile diary={diaryList} index={index} />
-              <div {...stylex.props(styles.smallDetailes)}>
-                <span {...stylex.props(styles.name)}>{diary.createdDate}</span>
-                <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
-              </div>
-            </div>
-            <div {...stylex.props(styles.diaryContent)}>
-              <div>
-                {diary.tags.map(tag => (
-                  <span {...stylex.props(styles.hashtag)} key={tag.id}>
-                    #{`${tag.tag} `}
+    <>
+      <div {...stylex.props(styles.diaryList)}>
+        {filterDiaryList.map((diary, index) => (
+          <Link key={diary.diaryId} to={`/diary/${diary.diaryId}`}>
+            <div {...stylex.props(styles.diary)} key={diary.diaryId}>
+              <div {...stylex.props(styles.smallProfileSection)}>
+                <MoodProfile diary={diaryList} index={index} />
+                <div {...stylex.props(styles.smallDetailes)}>
+                  <span {...stylex.props(styles.name)}>
+                    {diary.createdDate}
                   </span>
-                ))}
+                  <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
+                </div>
               </div>
-              <span>{diary.content}</span>
+              <div {...stylex.props(styles.diaryContent)}>
+                <div>
+                  {diary.tags.map(tag => (
+                    <span {...stylex.props(styles.hashtag)} key={tag.id}>
+                      #{`${tag.tag} `}
+                    </span>
+                  ))}
+                </div>
+                <span>{diary.content}</span>
+              </div>
+              <div {...stylex.props(styles.likeSection)}>
+                <Like />
+                <span>{diary.likeCount}</span>
+              </div>
             </div>
-            <div {...stylex.props(styles.likeSection)}>
-              <Like />
-              <span>{diary.likeCount}</span>
-            </div>
-          </div>
-        </Link>
-      ))}
-    </div>
+          </Link>
+        ))}
+      </div>
+      <div {...stylex.props(styles.pageButtonWrap)}>
+        {Array.from({ length: pageSize }, (_, index) => (
+          <button key={index} onClick={() => handlePageChange(index)}>
+            {index + 1}
+          </button>
+        ))}
+      </div>
+    </>
   );
 };
 

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -167,7 +167,7 @@ const styles = stylex.create({
     flexDirection: 'column',
 
     width: '100%',
-    minHeight: '1000px',
+    minHeight: '1050px',
 
     paddingBottom: '50px',
     overflowY: 'auto',
@@ -225,6 +225,14 @@ const styles = stylex.create({
   likeSection: {
     display: 'flex',
     alignItems: 'center',
+  },
+
+  pageButtonWrap: {
+    display: 'flex',
+    justifyContent: 'center',
+
+    paddingBottom: '60px',
+    gap: '10px',
   },
 });
 


### PR DESCRIPTION
## 마이 페이지 일기 목록 페이지 버튼 구현 (CLIENT-98)
### 🔎 AS-IS

- 현재 마이 페이지에 5개 이상의 일기가 작성되었을 시, 작성된 일기가 5개까지밖에 나타나지 않고 있습니다. 따라서 사용자가 작성한 일기를 모두 확인할 수 있도록 페이지 버튼 구현이 필요합니다.

### ✨TO-BE

- [x] 작성된 일기 수에 대응하는 페이지 버튼을 생성한다.
- [x] 버튼 클릭 시 해당하는 페이지에 사용자가 작성한 일기들이 나타난다.

![페이지 버튼](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/09a42328-75e2-41d4-a061-1595c123010d)