### PR TITLE
:sparkles: feat: Quill 작성 내용 HTML 렌더링 적용

### DIFF
--- a/grass-diary/package-lock.json
+++ b/grass-diary/package-lock.json
@@ -11,6 +11,7 @@
         "@stylexjs/stylex": "^0.5.1",
         "axios": "^1.6.7",
         "dayjs": "^1.11.10",
+        "dompurify": "^3.0.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.8.1",
@@ -6069,6 +6070,11 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.11.tgz",
+      "integrity": "sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",

--- a/grass-diary/package.json
+++ b/grass-diary/package.json
@@ -12,6 +12,7 @@
     "@stylexjs/stylex": "^0.5.1",
     "axios": "^1.6.7",
     "dayjs": "^1.11.10",
+    "dompurify": "^3.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.8.1",

--- a/grass-diary/src/components/Feed.jsx
+++ b/grass-diary/src/components/Feed.jsx
@@ -1,5 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import { Link } from 'react-router-dom';
+import DOMPurify from 'dompurify';
 
 const feed = stylex.create({
   box: {
@@ -49,6 +50,13 @@ const feed = stylex.create({
 });
 
 const Feed = ({ likeCount, link, title, content, name, profile }) => {
+  const createMarkup = htmlContent => {
+    return { __html: DOMPurify.sanitize(htmlContent) };
+  };
+
+  const processedContent =
+    content && content.length > 350 ? `${content.slice(0, 350)}...` : content;
+
   return (
     <Link to={link}>
       <article {...stylex.props(feed.box)}>
@@ -64,11 +72,10 @@ const Feed = ({ likeCount, link, title, content, name, profile }) => {
         </div>
 
         <div {...stylex.props(feed.title)}>{title}</div>
-        <div {...stylex.props(feed.content)}>
-          {content && content.length > 350
-            ? `${content.slice(0, 350)}...`
-            : content}
-        </div>
+        <div
+          {...stylex.props(feed.content)}
+          dangerouslySetInnerHTML={createMarkup(processedContent)}
+        />
       </article>
     </Link>
   );

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -10,6 +10,7 @@ import Like from '../../components/Like';
 import EMOJI from '../../constants/emoji';
 import testImg from '../../assets/icon/basicProfile.png';
 import Setting from './Setting';
+import DOMPurify from 'dompurify';
 
 const styles = stylex.create({
   wrap: {
@@ -154,6 +155,10 @@ const Diary = () => {
     fetchDiaryData();
   }, []);
 
+  const createMarkup = htmlContent => {
+    return { __html: DOMPurify.sanitize(htmlContent) };
+  };
+
   return (
     <>
       <Header />
@@ -192,7 +197,10 @@ const Diary = () => {
               return `#${tag.tag} `;
             })}
           </div>
-          <p {...stylex.props(contentStyle.content)}>{diary.content}</p>
+          <div
+            {...stylex.props(contentStyle.content)}
+            dangerouslySetInnerHTML={createMarkup(diary.content)}
+          />
         </div>
 
         {/* 일기 하단 */}

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -2,6 +2,7 @@ import stylex from '@stylexjs/stylex';
 import styles from './style';
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import DOMPurify from 'dompurify';
 
 import API from '../../services';
 import Like from '../../components/Like';
@@ -226,6 +227,10 @@ const Diary = ({ searchTerm, sortOrder }) => {
     setCurrentPage(page);
   };
 
+  const createMarkup = htmlContent => {
+    return { __html: DOMPurify.sanitize(htmlContent) };
+  };
+
   return (
     <>
       <div {...stylex.props(styles.diaryList)}>
@@ -249,7 +254,9 @@ const Diary = ({ searchTerm, sortOrder }) => {
                     </span>
                   ))}
                 </div>
-                <span>{diary.content}</span>
+                <div
+                  dangerouslySetInnerHTML={createMarkup(diary.content)}
+                ></div>
               </div>
               <div {...stylex.props(styles.likeSection)}>
                 <Like />


### PR DESCRIPTION
## QuillEditor

<img width="1185" alt="스크린샷 2024-03-30 오후 1 26 07" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/102516350/32f1bde6-d247-4061-b83a-e79a3fa8807f">

<br>
<br>

- Quill로 작성한 내용 전달에 HTML 태그가 적용되지 않고 그대로 노출
- HTML을 안전하게 렌더링하지 않고 텍스트로 처리
- 적용 되려면 HTML을 DOM에 직접 삽입
- 사용자가 입력한 HTML을 그대로 웹 페이지에 삽입하는 것은 XSS(Cross-Site Scripting)에 취약
- React의 dangerouslySetInnerHTML 속성을 사용하여 HTML문자열을 직접 DOM에 삽입
- dangerouslySetInnerHTML 사용할 때는 XSS를 방지하기 위해 sanitize(살균) 처리
- [dompurify 라이브러리 사용](https://meldu.tistory.com/25)

e.g.

```javascript
import DOMPurify from 'dompurify';

// 살균된 내용을 안전하게 렌더링하기 위한 함수
  const createMarkup = (htmlContent) => {
    return { __html: DOMPurify.sanitize(htmlContent) };
  };
  
  
  // 사용예시
  
   <div dangerouslySetInnerHTML={createMarkup(diary.content)}/></div>
```

<br>
<br>

<img width="1211" alt="스크린샷 2024-03-30 오후 2 35 59" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/102516350/1cb551b1-8472-4fb2-801d-bd7fbf4b9751">

