### PR TITLE
♻ refactor: 클릭 제한된 좋아요 컴포넌트 분리 및 적용

### DIFF
--- a/grass-diary/src/components/Feed.jsx
+++ b/grass-diary/src/components/Feed.jsx
@@ -1,5 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import { Link } from 'react-router-dom';
+import NormalLike from './normalLike';
 
 const feed = stylex.create({
   box: {
@@ -16,11 +17,6 @@ const feed = stylex.create({
     },
     transition: '0.3s',
     overflow: 'hidden',
-  },
-  like: {
-    display: 'flex',
-    gap: '5px',
-    justifyContent: 'flex-end',
   },
   header: {
     display: 'flex',
@@ -52,12 +48,7 @@ const Feed = ({ likeCount, link, title, content, name, profile }) => {
   return (
     <Link to={link}>
       <article {...stylex.props(feed.box)}>
-        <div {...stylex.props(feed.like)}>
-          <span>
-            <i className="fa-solid fa-heart"></i>
-          </span>
-          <span>{likeCount}</span>
-        </div>
+        <NormalLike likeCount={likeCount} justifyContent={'flex-end'} />
         <div {...stylex.props(feed.header)}>
           <img {...stylex.props(feed.img)} src={profile}></img>
           <div {...stylex.props(feed.name)}>{name}</div>

--- a/grass-diary/src/components/NormalLike.jsx
+++ b/grass-diary/src/components/NormalLike.jsx
@@ -1,0 +1,22 @@
+import * as stylex from '@stylexjs/stylex';
+
+const feed = stylex.create({
+  like: justifyContent => ({
+    display: 'flex',
+    gap: '15px',
+    justifyContent: justifyContent,
+  }),
+});
+
+const NormalLike = ({ likeCount, justifyContent }) => {
+  return (
+    <div {...stylex.props(feed.like(justifyContent))}>
+      <span>
+        <i className="fa-solid fa-heart"></i>
+      </span>
+      <span>{likeCount}</span>
+    </div>
+  );
+};
+
+export default NormalLike;

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import API from '../../services';
-import Like from '../../components/Like';
+import NormalLike from '../../components/normalLike';
 import Button from '../../components/Button';
 import { EllipsisBox, EllipsisIcon } from '../../components/Ellipsis';
 import MoodProfile from '../../components/MoodProfile';
@@ -241,10 +241,7 @@ const Diary = ({ searchTerm, sortOrder }) => {
               </div>
               <span>{diary.content}</span>
             </div>
-            <div {...stylex.props(styles.likeSection)}>
-              <Like />
-              <span>{diary.likeCount}</span>
-            </div>
+            <NormalLike likeCount={diary.likeCount} />
           </div>
         </Link>
       ))}

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -221,11 +221,6 @@ const styles = stylex.create({
     color: '#474747',
     gap: '20px',
   },
-
-  likeSection: {
-    display: 'flex',
-    alignItems: 'center',
-  },
 });
 
 export default styles;


### PR DESCRIPTION
# NormalLike 컴포넌트 생성
- 마이페이지 및 공유페이지 피드에 적용해두었습니다. 
```
// import 후 
import NormalLike from './normalLike'; 
...
// 사용
<NormalLike likeCount={likeCount} justifyContent={'flex-end'} />
```
### 컴포넌트 파라미터 
- likeCount를 주게 되면 하트 옆에 숫자 표기 가능
- justifyContent 값에 따라 왼쪽 정렬, 중앙정렬, 오른쪽 정렬 선택 가능. 
- justifyContent 값을 아예 주지 않으면 기본 왼쪽 정렬.
