### PR TITLE
:sparkles: feat: 마이페이지 잔디 구현 (CLIENT-61)

### DIFF
--- a/grass-diary/src/hooks/useDiary.js
+++ b/grass-diary/src/hooks/useDiary.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import API from '../services';
+
+const useDiary = (memberId, currentPage, sortOrder) => {
+  const [diaryList, setDiaryList] = useState([]);
+  const [pageSize, setPageSize] = useState(0);
+
+  useEffect(() => {
+    let apiUrl = `/diary/main/${memberId}?page=${currentPage}`;
+    if (sortOrder === 'oldest') {
+      apiUrl += `&sort=createdAt,ASC`;
+    }
+
+    if (memberId) {
+      API.get(apiUrl)
+        .then(response => {
+          setPageSize(response.data.totalPages);
+          setDiaryList(response.data.content);
+        })
+        .catch(error => {
+          console.log(`사용자의 일기를 조회할 수 없습니다. ${error}`);
+        });
+    }
+  }, [memberId, sortOrder, currentPage]);
+
+  return { diaryList, pageSize };
+};
+
+export default useDiary;

--- a/grass-diary/src/hooks/ussGrass.js
+++ b/grass-diary/src/hooks/ussGrass.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { formatDate } from '../utils/dateUtils';
+import API from '../services';
+import useUser from './useUser';
+
+const useGrass = () => {
+  const memberId = useUser();
+  const [grassColors, setGrassColors] = useState({});
+
+  useEffect(() => {
+    if (memberId) {
+      API.get(`/grass/${memberId}`)
+        .then(response => {
+          const { grassList } = response.data;
+          const grassColor = response.data.colorRGB;
+          const updatedGrassColors = {};
+
+          grassList.forEach(grass => {
+            const { createdAt, transparency } = grass;
+            const createdDate = formatDate(new Date(createdAt));
+            updatedGrassColors[createdDate] = `${grassColor},${transparency}`;
+          });
+
+          setGrassColors(updatedGrassColors);
+        })
+        .catch(error =>
+          console.error(`사용자 잔디 현황을 불러올 수 없습니다. ${error}`),
+        );
+    }
+  }, [memberId]);
+
+  return grassColors;
+};
+
+export default useGrass;

--- a/grass-diary/src/pages/MyPage/Diary.jsx
+++ b/grass-diary/src/pages/MyPage/Diary.jsx
@@ -1,0 +1,86 @@
+import styles from './style';
+import stylex from '@stylexjs/stylex';
+import DOMPurify from 'dompurify';
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+
+import useUser from '../../hooks/useUser';
+import useDiary from '../../hooks/useDiary';
+import NormalLike from '../../components/normalLike';
+import MoodProfile from '../../components/MoodProfile';
+
+const Pagination = ({ pageSize, onPageChange }) => {
+  return (
+    <div {...stylex.props(styles.pageButtonWrap)}>
+      {Array.from({ length: pageSize }, (_, index) => (
+        <button key={index} onClick={() => onPageChange(index)}>
+          {index + 1}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+const DiaryItem = ({ diary, diaryList, index }) => {
+  const createMarkup = htmlContent => {
+    return { __html: DOMPurify.sanitize(htmlContent) };
+  };
+
+  return (
+    <Link to={`/diary/${diary.diaryId}`}>
+      <div {...stylex.props(styles.diary)}>
+        <div {...stylex.props(styles.smallProfileSection)}>
+          <MoodProfile diary={diaryList} index={index} />
+          <div {...stylex.props(styles.smallDetailes)}>
+            <span {...stylex.props(styles.name)}>{diary.createdDate}</span>
+            <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
+          </div>
+        </div>
+        <div {...stylex.props(styles.diaryContent)}>
+          <div>
+            {diary.tags.map(tag => (
+              <span {...stylex.props(styles.hashtag)} key={tag.id}>
+                #{`${tag.tag} `}
+              </span>
+            ))}
+          </div>
+          <div dangerouslySetInnerHTML={createMarkup(diary.content)}></div>
+        </div>
+        <NormalLike likeCount={diary.likeCount} />
+      </div>
+    </Link>
+  );
+};
+
+const Diary = ({ searchTerm, sortOrder, selectedDiary }) => {
+  const memberId = useUser();
+  const [currentPage, setCurrentPage] = useState(0);
+  const { diaryList, pageSize } = useDiary(memberId, currentPage, sortOrder);
+
+  const filteredDiaryList =
+    selectedDiary && selectedDiary.diaryId
+      ? [selectedDiary]
+      : diaryList.filter(diary => diary.content.includes(searchTerm));
+
+  const handlePageChange = page => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <>
+      <div {...stylex.props(styles.diaryList)}>
+        {filteredDiaryList.map((diary, index) => (
+          <DiaryItem
+            key={diary.diaryId}
+            diary={diary}
+            diaryList={filteredDiaryList}
+            index={index}
+          />
+        ))}
+      </div>
+      <Pagination pageSize={pageSize} onPageChange={handlePageChange} />
+    </>
+  );
+};
+
+export default Diary;

--- a/grass-diary/src/pages/MyPage/Grass.jsx
+++ b/grass-diary/src/pages/MyPage/Grass.jsx
@@ -1,0 +1,70 @@
+import stylex from '@stylexjs/stylex';
+import styles from './style';
+import { useState } from 'react';
+import { formatDate } from '../../utils/dateUtils';
+import { getDaysArray } from '../../utils/dateUtils';
+import useGrass from '../../hooks/ussGrass';
+
+const createGrass = () => {
+  const year = new Date().getFullYear();
+  const days = getDaysArray(year);
+  const columns = Math.ceil(days.length / 7);
+
+  // 1년을 7으로 나눈 수만큼 잔디 배열 생성 (default: null)
+  const grass = Array.from({ length: columns }, () => Array(7).fill(null));
+
+  // 잔디 배열에 해당하는 날짜 저장
+  days.forEach((day, index) => {
+    const column = Math.floor(index / 7);
+    const row = index % 7;
+
+    grass[column][row] = day;
+  });
+
+  return grass;
+};
+
+const Grass = () => {
+  const [selectedGrass, setSelectedGrass] = useState(null);
+  const grassColors = useGrass();
+  const grass = createGrass();
+
+  const handleGrassClick = date => {
+    setSelectedGrass(formatDate(date));
+  };
+
+  return (
+    <div {...stylex.props(styles.grassContainer)}>
+      {grass.map((column, index) => (
+        <div key={index} {...stylex.props(styles.grass)}>
+          {column.map((day, index) => {
+            if (day === null) return null;
+            const writeDay = formatDate(day);
+            return (
+              <div key={index} {...stylex.props(styles.dayContainer)}>
+                <div
+                  onClick={() => handleGrassClick(day)}
+                  {...stylex.props(
+                    styles.grassDate(
+                      writeDay === selectedGrass ? '1px solid black' : 'none',
+                      grassColors[writeDay]
+                        ? `rgba(${grassColors[writeDay]})`
+                        : '#E0E0E0',
+                    ),
+                  )}
+                ></div>
+                {formatDate(day) === selectedGrass && (
+                  <div {...stylex.props(styles.dateBubble)}>
+                    <span>{selectedGrass}</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Grass;

--- a/grass-diary/src/pages/MyPage/Grass.jsx
+++ b/grass-diary/src/pages/MyPage/Grass.jsx
@@ -1,9 +1,11 @@
 import stylex from '@stylexjs/stylex';
 import styles from './style';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { formatDate } from '../../utils/dateUtils';
 import { getDaysArray } from '../../utils/dateUtils';
 import useGrass from '../../hooks/ussGrass';
+import API from '../../services';
+import useUser from '../../hooks/useUser';
 
 const createGrass = () => {
   const year = new Date().getFullYear();
@@ -21,17 +23,32 @@ const createGrass = () => {
     grass[column][row] = day;
   });
 
-  return grass;
+  return { year, grass };
 };
 
-const Grass = () => {
+const Grass = ({ setSelectedDiary }) => {
   const [selectedGrass, setSelectedGrass] = useState(null);
+  const { year, grass } = createGrass();
+  const memberId = useUser();
   const grassColors = useGrass();
-  const grass = createGrass();
 
   const handleGrassClick = date => {
     setSelectedGrass(formatDate(date));
   };
+
+  useEffect(() => {
+    if (selectedGrass) {
+      const selectedDate = `${year}-${selectedGrass.split('/').join('-')}`;
+
+      API.get(`/search/date/${memberId}?date=${selectedDate}`)
+        .then(response => {
+          setSelectedDiary(response.data);
+        })
+        .catch(error => {
+          console.error(error);
+        });
+    }
+  }, [selectedGrass, memberId, setSelectedDiary, year]);
 
   return (
     <div {...stylex.props(styles.grassContainer)}>

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -126,47 +126,41 @@ const formatDate = selectedDate => {
 };
 
 const Grass = () => {
-  const [selectedCell, setSelectedCell] = useState(null);
+  const year = new Date().getFullYear();
+  const isLeapYear = new Date(year, 1, 29).getMonth() === 1;
+  const daysInYear = isLeapYear ? 366 : 365;
 
-  const startDate = new Date(2024, 0, 1);
-  const endDate = new Date(2024, 11, 31);
-  const oneDay = 24 * 60 * 60 * 1000;
-  const length = Math.round(Math.abs((endDate - startDate) / oneDay)) + 1;
+  const columns = Math.ceil(daysInYear / 7);
+  const days = Array.from(
+    { length: daysInYear },
+    (_, i) => new Date(year, 0, i + 1),
+  );
 
-  const data = Array.from({ length }, (_, i) => {
-    const date = new Date(startDate.getTime() + i * oneDay);
+  const grass = Array.from({ length: columns }, () => Array(7).fill(null));
 
-    return {
-      date: `${date.getMonth() + 1}/${date.getDate()}`,
-    };
+  days.forEach((day, index) => {
+    const column = Math.floor(index / 7);
+    const row = index % 7;
+
+    grass[column][row] = day;
   });
-
-  const handleClick = date => {
-    setSelectedCell(date);
-  };
 
   return (
     <div {...stylex.props(styles.grassContainer)}>
-      <table {...stylex.props(styles.grass)}>
-        <tbody>
-          {Array.from({ length: 7 }, (_, i) => (
-            <tr key={i}>
-              {data.slice(i * 52, (i + 1) * 52).map((item, j) => (
-                <td
-                  onClick={() => handleClick(item.date)}
-                  key={j}
-                  {...stylex.props(
-                    styles.grassDate(
-                      item.date === selectedCell ? '1px solid black' : 'none',
-                    ),
-                  )}
-                ></td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <span>2024</span>
+      {grass.map((column, index) => (
+        <div key={index} {...stylex.props(styles.grass)}>
+          {column.map((day, index) => {
+            if (day === null) return null;
+            return (
+              <div key={index} {...stylex.props(styles.dayContainer)}>
+                <div
+                  {...stylex.props(styles.grassDate('none', '#E0E0E0'))}
+                ></div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
     </div>
   );
 };

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -12,6 +12,7 @@ import MoodProfile from '../../components/MoodProfile';
 import Profile from '../../components/Profile';
 import useUser from '../../hooks/useUser';
 import useProfile from '../../hooks/useProfile';
+import Grass from './Grass';
 
 const Container = ({ children }) => {
   return <div {...stylex.props(styles.container)}>{children}</div>;
@@ -113,100 +114,6 @@ const ProfileImage = () => {
           <span>{profileIntro !== null ? profileIntro : '소개글입니다.'}</span>
         </div>
       </div>
-    </div>
-  );
-};
-
-const formatDate = selectedDate => {
-  const date = new Date(selectedDate);
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-
-  return [month, day].join('/');
-};
-
-const Grass = () => {
-  const memberId = useUser();
-  const [selectedGrass, setSelectedGrass] = useState(null);
-  const [grassColors, setGrassColors] = useState({});
-
-  const year = new Date().getFullYear();
-  const isLeapYear = new Date(year, 1, 29).getMonth() === 1;
-  const daysInYear = isLeapYear ? 366 : 365;
-
-  const columns = Math.ceil(daysInYear / 7);
-  const days = Array.from(
-    { length: daysInYear },
-    (_, i) => new Date(year, 0, i + 1),
-  );
-
-  const grass = Array.from({ length: columns }, () => Array(7).fill(null));
-
-  days.forEach((day, index) => {
-    const column = Math.floor(index / 7);
-    const row = index % 7;
-
-    grass[column][row] = day;
-  });
-
-  const handleGrassClick = date => {
-    setSelectedGrass(formatDate(date));
-  };
-
-  useEffect(() => {
-    if (memberId) {
-      API.get(`/grass/${memberId}`)
-        .then(response => {
-          const { grassList } = response.data;
-          const grassColor = response.data.colorRGB;
-          const updatedGrassColors = {};
-
-          grassList.forEach(grass => {
-            const { createdAt, transparency } = grass;
-            const createdDate = formatDate(new Date(createdAt));
-
-            updatedGrassColors[createdDate] = `${grassColor},${transparency}`;
-          });
-
-          setGrassColors(updatedGrassColors);
-        })
-        .catch(error =>
-          console.error(`사용자 잔디 현황을 불러올 수 없습니다. ${error}`),
-        );
-    }
-  }, [memberId]);
-
-  return (
-    <div {...stylex.props(styles.grassContainer)}>
-      {grass.map((column, index) => (
-        <div key={index} {...stylex.props(styles.grass)}>
-          {column.map((day, index) => {
-            if (day === null) return null;
-            const writeDay = formatDate(day);
-
-            return (
-              <div key={index} {...stylex.props(styles.dayContainer)}>
-                <div
-                  onClick={() => handleGrassClick(day)}
-                  {...stylex.props(
-                    styles.grassDate(
-                      writeDay === selectedGrass ? '1px solid black' : 'none',
-                      grassColors[writeDay]
-                        ? `rgba(${grassColors[writeDay]})`
-                        : '#E0E0E0',
-                    ),
-                  )}
-                ></div>
-                {formatDate(day) === selectedGrass && (
-                  <div {...stylex.props(styles.dateBubble)}>
-                    <span>{selectedGrass}</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      ))}
     </div>
   );
 };

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -117,6 +117,14 @@ const ProfileImage = () => {
   );
 };
 
+const formatDate = selectedDate => {
+  const date = new Date(selectedDate);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return [month, day].join('/');
+};
+
 const Grass = () => {
   const [selectedCell, setSelectedCell] = useState(null);
 

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -1,18 +1,14 @@
 import stylex from '@stylexjs/stylex';
 import styles from './style';
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import DOMPurify from 'dompurify';
+import { useNavigate } from 'react-router-dom';
 
-import API from '../../services';
-import NormalLike from '../../components/normalLike';
 import Button from '../../components/Button';
 import { EllipsisBox, EllipsisIcon } from '../../components/Ellipsis';
-import MoodProfile from '../../components/MoodProfile';
 import Profile from '../../components/Profile';
-import useUser from '../../hooks/useUser';
 import useProfile from '../../hooks/useProfile';
 import Grass from './Grass';
+import Diary from './Diary';
 
 const Container = ({ children }) => {
   return <div {...stylex.props(styles.container)}>{children}</div>;
@@ -24,6 +20,7 @@ const MainContainer = () => {
   const [toggleButton, setToggleButton] = useState('나의 일기장');
   const [searchTerm, setSearchTerm] = useState('');
   const [sortOrder, setSortOrder] = useState('latest');
+  const [selectedDiary, setSelectedDiary] = useState([]);
 
   const handleToggleButton = buttonName => {
     setToggleButton(buttonName);
@@ -48,7 +45,7 @@ const MainContainer = () => {
   return (
     <div {...stylex.props(styles.mainContainer)}>
       <div {...stylex.props(styles.profileSection)}>
-        <ProfileImage />
+        <ProfileSection setSelectedDiary={setSelectedDiary} />
         <ToggleButton
           buttonLabel={toggleButton}
           handleToggleButton={handleToggleButton}
@@ -58,7 +55,11 @@ const MainContainer = () => {
         <SearchBar onSearchChange={handleSearchChange} />
         <SortButton onSortChange={handleSortChange} />
         {toggleButton === '나의 일기장' ? (
-          <Diary searchTerm={searchTerm} sortOrder={sortOrder} />
+          <Diary
+            searchTerm={searchTerm}
+            sortOrder={sortOrder}
+            selectedDiary={selectedDiary}
+          />
         ) : (
           <p>현재 교환 일기가 없습니다.</p>
         )}
@@ -87,7 +88,7 @@ const ToggleButton = ({ buttonLabel, handleToggleButton }) => {
   );
 };
 
-const ProfileImage = () => {
+const ProfileSection = ({ setSelectedDiary }) => {
   const { nickname, profileIntro } = useProfile();
 
   return (
@@ -109,7 +110,7 @@ const ProfileImage = () => {
         <div {...stylex.props(styles.nameSection)}>
           <span>{nickname}</span>
         </div>
-        <Grass />
+        <Grass setSelectedDiary={setSelectedDiary} />
         <div>
           <span>{profileIntro !== null ? profileIntro : '소개글입니다.'}</span>
         </div>
@@ -147,85 +148,6 @@ const SortButton = ({ onSortChange }) => {
         />
       </EllipsisIcon>
     </div>
-  );
-};
-
-const Diary = ({ searchTerm, sortOrder }) => {
-  const memberId = useUser();
-  const [diaryList, setDiaryList] = useState([]);
-  const [pageSize, setPageSize] = useState(0);
-  const [currentPage, setCurrentPage] = useState(0);
-
-  useEffect(() => {
-    let apiUrl = `/diary/main/${memberId}?page=${currentPage}`;
-    if (sortOrder === 'oldest') {
-      apiUrl += `&sort=createdAt,ASC`;
-    }
-
-    if (memberId) {
-      API.get(apiUrl)
-        .then(response => {
-          setPageSize(response.data.totalPages);
-          setDiaryList(response.data.content);
-        })
-        .catch(error => {
-          console.log(`사용자의 일기를 조회할 수 없습니다. ${error}`);
-        });
-    }
-  }, [memberId, sortOrder, currentPage]);
-
-  const filterDiaryList = diaryList.filter(diary =>
-    diary.content.includes(searchTerm),
-  );
-
-  const handlePageChange = page => {
-    setCurrentPage(page);
-  };
-
-  const createMarkup = htmlContent => {
-    return { __html: DOMPurify.sanitize(htmlContent) };
-  };
-
-  return (
-    <>
-      <div {...stylex.props(styles.diaryList)}>
-        {filterDiaryList.map((diary, index) => (
-          <Link key={diary.diaryId} to={`/diary/${diary.diaryId}`}>
-            <div {...stylex.props(styles.diary)} key={diary.diaryId}>
-              <div {...stylex.props(styles.smallProfileSection)}>
-                <MoodProfile diary={diaryList} index={index} />
-                <div {...stylex.props(styles.smallDetailes)}>
-                  <span {...stylex.props(styles.name)}>
-                    {diary.createdDate}
-                  </span>
-                  <span {...stylex.props(styles.time)}>{diary.createdAt}</span>
-                </div>
-              </div>
-              <div {...stylex.props(styles.diaryContent)}>
-                <div>
-                  {diary.tags.map(tag => (
-                    <span {...stylex.props(styles.hashtag)} key={tag.id}>
-                      #{`${tag.tag} `}
-                    </span>
-                  ))}
-                </div>
-                <div
-                  dangerouslySetInnerHTML={createMarkup(diary.content)}
-                ></div>
-              </div>
-              <NormalLike likeCount={diary.likeCount} />
-            </div>
-          </Link>
-        ))}
-      </div>
-      <div {...stylex.props(styles.pageButtonWrap)}>
-        {Array.from({ length: pageSize }, (_, index) => (
-          <button key={index} onClick={() => handlePageChange(index)}>
-            {index + 1}
-          </button>
-        ))}
-      </div>
-    </>
   );
 };
 

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -126,6 +126,8 @@ const formatDate = selectedDate => {
 };
 
 const Grass = () => {
+  const [selectedGrass, setSelectedGrass] = useState(null);
+
   const year = new Date().getFullYear();
   const isLeapYear = new Date(year, 1, 29).getMonth() === 1;
   const daysInYear = isLeapYear ? 366 : 365;
@@ -145,6 +147,10 @@ const Grass = () => {
     grass[column][row] = day;
   });
 
+  const handleGrassClick = date => {
+    setSelectedGrass(formatDate(date));
+  };
+
   return (
     <div {...stylex.props(styles.grassContainer)}>
       {grass.map((column, index) => (
@@ -154,8 +160,21 @@ const Grass = () => {
             return (
               <div key={index} {...stylex.props(styles.dayContainer)}>
                 <div
-                  {...stylex.props(styles.grassDate('none', '#E0E0E0'))}
+                  onClick={() => handleGrassClick(day)}
+                  {...stylex.props(
+                    styles.grassDate(
+                      formatDate(day) === selectedGrass
+                        ? '1px solid black'
+                        : 'none',
+                      '#E0E0E0',
+                    ),
+                  )}
                 ></div>
+                {formatDate(day) === selectedGrass && (
+                  <div {...stylex.props(styles.dateBubble)}>
+                    <span>{selectedGrass}</span>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -76,22 +76,31 @@ const styles = stylex.create({
   grassContainer: {
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'flex-end',
+  },
 
-    gap: '10px',
+  dayContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+
+    position: 'relative',
   },
 
   grass: {
     width: '100%',
+    position: 'relative',
   },
 
-  grassDate: border => ({
-    borderRadius: '10px',
-    backgroundColor: '#B6F69D',
-    width: '10px',
+  grassDate: (border, backgroundColor) => ({
+    position: 'relative',
+
+    width: '13px',
     height: '13px',
 
+    borderRadius: '100%',
+
     border,
+    backgroundColor,
   }),
 
   profileToggle: {
@@ -221,6 +230,7 @@ const styles = stylex.create({
     color: '#474747',
     gap: '20px',
   },
+
   pageButtonWrap: {
     display: 'flex',
     justifyContent: 'center',

--- a/grass-diary/src/pages/MyPage/style.js
+++ b/grass-diary/src/pages/MyPage/style.js
@@ -103,6 +103,26 @@ const styles = stylex.create({
     backgroundColor,
   }),
 
+  dateBubble: {
+    position: 'absolute',
+
+    width: '50px',
+    padding: '8px',
+
+    top: '20px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+
+    fontSize: '11px',
+    textAlign: 'center',
+
+    border: '1px solid #BFBFBF',
+    borderRadius: '20px',
+    backgroundColor: '#FFF',
+
+    zIndex: '3',
+  },
+
   profileToggle: {
     display: 'flex',
   },

--- a/grass-diary/src/utils/dateUtils.js
+++ b/grass-diary/src/utils/dateUtils.js
@@ -1,0 +1,19 @@
+const formatDate = selectedDate => {
+  const date = new Date(selectedDate);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return [month, day].join('/');
+};
+
+const getDaysInYear = year => {
+  const isLeapYear = new Date(year, 1, 29).getMonth() === 1;
+  return isLeapYear ? 366 : 365;
+};
+
+const getDaysArray = year => {
+  const daysInYear = getDaysInYear(year);
+  return Array.from({ length: daysInYear }, (_, i) => new Date(year, 0, i + 1));
+};
+
+export { formatDate, getDaysInYear, getDaysArray };


### PR DESCRIPTION
## 마이페이지 잔디 구현 (CLIENT-61)
### 🔎 AS-IS

- 현재 마이 페이지의 UI만 임의적으로 구현된 상태입니다. 따라서 서버에서 데이터를 받아와 사용자의 잔디에 일부 정보를 담아 마이 페이지의 상단에 나타내야 합니다.

### ✨ TO-BE

- [x] 일기 작성 시 작성된 날짜에 대응하는 잔디가 사용자가 지정한 색상으로 변경된다.
  - [x] 이때, 사용자가 일기 작성 시 설정한 기분에 따라 투명도가 변경된다.
- [x] 잔디 클릭 시 잔디 날짜에 해당하는 일기가 나타난다.