### PR TITLE
🔧 chore: 절대 경로 설정 (CLIENT-103)

### DIFF
--- a/grass-diary/jsconfig.json
+++ b/grass-diary/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./jsconfig.paths.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES6"
+  },
+  "include": ["src/**/*"]
+}

--- a/grass-diary/jsconfig.paths.json
+++ b/grass-diary/jsconfig.paths.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@assets/*": ["src/assets/*"],
+      "@components/*": ["src/components/*"],
+      "@constants/*": ["src/constants/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@pages/*": ["src/pages/*"],
+      "@services/*": ["src/services/*"],
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}

--- a/grass-diary/src/components/BackButton.jsx
+++ b/grass-diary/src/components/BackButton.jsx
@@ -1,4 +1,4 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import { useNavigate } from 'react-router-dom';
 
 const styles = stylex.create({

--- a/grass-diary/src/components/Ellipsis.jsx
+++ b/grass-diary/src/components/Ellipsis.jsx
@@ -1,4 +1,4 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import { useState, useRef, useEffect } from 'react';
 
 const ellipsis = stylex.create({

--- a/grass-diary/src/components/Feed.jsx
+++ b/grass-diary/src/components/Feed.jsx
@@ -1,7 +1,7 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import { Link } from 'react-router-dom';
-import NormalLike from './NormalLike';
 import DOMPurify from 'dompurify';
+import NormalLike from './NormalLike';
 
 const feed = stylex.create({
   box: {

--- a/grass-diary/src/components/Header.jsx
+++ b/grass-diary/src/components/Header.jsx
@@ -1,9 +1,10 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
+
+import { clearAuth } from '@utils/authUtils';
 import Profile from './Profile';
-import { clearAuth } from '../utils/authUtils';
-import useUser from '../hooks/useUser';
+import useUser from '@hooks/useUser';
 
 const header = stylex.create({
   container: {

--- a/grass-diary/src/components/Like.jsx
+++ b/grass-diary/src/components/Like.jsx
@@ -1,7 +1,7 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 import { useEffect, useState } from 'react';
-import API from '../services';
-import useUser from '../hooks/useUser';
+import API from '@services';
+import useUser from '@hooks/useUser';
 
 const beat1 = stylex.keyframes({
   '0%': { transform: 'scale(0.8)' },

--- a/grass-diary/src/components/MoodProfile.jsx
+++ b/grass-diary/src/components/MoodProfile.jsx
@@ -1,7 +1,7 @@
+import stylex from '@stylexjs/stylex';
 import { useState, useMemo } from 'react';
 import Profile from './Profile';
-import stylex from '@stylexjs/stylex';
-import EMOJI from '../constants/emoji';
+import EMOJI from '@constants/emoji';
 
 const styles = stylex.create({
   emoji: {

--- a/grass-diary/src/components/NormalLike.jsx
+++ b/grass-diary/src/components/NormalLike.jsx
@@ -1,4 +1,4 @@
-import * as stylex from '@stylexjs/stylex';
+import stylex from '@stylexjs/stylex';
 
 const feed = stylex.create({
   like: justifyContent => ({

--- a/grass-diary/src/components/Profile.jsx
+++ b/grass-diary/src/components/Profile.jsx
@@ -1,5 +1,5 @@
 import stylex from '@stylexjs/stylex';
-import useProfile from '../hooks/useProfile';
+import useProfile from '@hooks/useProfile';
 
 const styles = stylex.create({
   profileImage: (width, height) => ({

--- a/grass-diary/src/components/ProtectedRoute.jsx
+++ b/grass-diary/src/components/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import { Outlet, Navigate } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth';
+import { useAuth } from '@hooks/useAuth';
 
 const ProtectedRoute = () => {
   const { isAuthenticated, isLoading } = useAuth();

--- a/grass-diary/src/components/Top10Feed.jsx
+++ b/grass-diary/src/components/Top10Feed.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import * as stylex from '@stylexjs/stylex';
-
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import Slider from 'react-slick';
-import API from '../services';
+
+import API from '@services';
 import Feed from './Feed';
 
 const styles = stylex.create({

--- a/grass-diary/src/hooks/useAuth.js
+++ b/grass-diary/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { checkAuth } from '../utils/authUtils';
+import { checkAuth } from '@utils/authUtils';
 
 export const useAuth = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);

--- a/grass-diary/src/hooks/useDiary.js
+++ b/grass-diary/src/hooks/useDiary.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import API from '../services';
+import API from '@services';
 
 const useDiary = (memberId, currentPage, sortOrder) => {
   const [diaryList, setDiaryList] = useState([]);

--- a/grass-diary/src/hooks/useProfile.js
+++ b/grass-diary/src/hooks/useProfile.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import useUser from './useUser';
-import API from '../services';
+import API from '@services';
 
 const useProfile = () => {
   const memberId = useUser();

--- a/grass-diary/src/hooks/useUser.js
+++ b/grass-diary/src/hooks/useUser.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from './useAuth';
-import API from '../services/index';
+import API from '@services';
 
 const useUser = () => {
   const [memberId, setMemberId] = useState(null);

--- a/grass-diary/src/hooks/ussGrass.js
+++ b/grass-diary/src/hooks/ussGrass.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { formatDate } from '../utils/dateUtils';
-import API from '../services';
+import { formatDate } from '@utils/dateUtils';
 import useUser from './useUser';
+import API from '@services';
 
 const useGrass = () => {
   const memberId = useUser();

--- a/grass-diary/src/main.jsx
+++ b/grass-diary/src/main.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
-import '../src/styles/reset.css';
+import './styles/reset.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.jsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.jsx
@@ -1,15 +1,17 @@
 import * as stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import API from '../../services';
-import Header from '../../components/Header';
-import BackButton from '../../components/BackButton';
-import QuillEditor from './QuillEditor';
 import dayjs from 'dayjs';
 import Swal from 'sweetalert2';
-import EMOJI from '../../constants/emoji';
-import useUser from '../../hooks/useUser';
+import QuillEditor from './QuillEditor';
+
+import API from '@services';
+import useUser from '@hooks/useUser';
+import Header from '@components/Header';
+import BackButton from '@components/BackButton';
+import EMOJI from '@constants/emoji';
 import 'dayjs/locale/ko';
+
 dayjs.locale('ko');
 
 const CreateDiaryStyle = stylex.create({

--- a/grass-diary/src/pages/CreateDiary/QuillEditor.jsx
+++ b/grass-diary/src/pages/CreateDiary/QuillEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import API from '../../services';
+import API from '@services';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 

--- a/grass-diary/src/pages/Diary/Diary.jsx
+++ b/grass-diary/src/pages/Diary/Diary.jsx
@@ -1,16 +1,16 @@
 import * as stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-
-import API from '../../services/index';
-import useUser from '../../hooks/useUser';
-import Header from '../../components/Header';
-import BackButton from '../../components/BackButton';
-import Like from '../../components/Like';
-import EMOJI from '../../constants/emoji';
-import testImg from '../../assets/icon/basicProfile.png';
-import Setting from './Setting';
 import DOMPurify from 'dompurify';
+
+import testImg from '@assets/icon/basicProfile.png';
+import API from '@services';
+import useUser from '@hooks/useUser';
+import Header from '@components/Header';
+import BackButton from '@components/BackButton';
+import Like from '@components/Like';
+import EMOJI from '@constants/emoji';
+import Setting from './Setting';
 
 const styles = stylex.create({
   wrap: {

--- a/grass-diary/src/pages/Diary/NonExistentDiary.jsx
+++ b/grass-diary/src/pages/Diary/NonExistentDiary.jsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
-import Header from '../../components/Header';
-import BackButton from '../../components/BackButton';
+import Header from '@components/Header';
+import BackButton from '@components/BackButton';
 
 const styles = stylex.create({
   wrap: {

--- a/grass-diary/src/pages/Diary/Setting.jsx
+++ b/grass-diary/src/pages/Diary/Setting.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
-import API from '../../services/index';
-import { EllipsisIcon, EllipsisBox } from '../../components/Ellipsis';
+import API from '@services';
+import { EllipsisIcon, EllipsisBox } from '@components/Ellipsis';
 import UnmodifyModal from './modal/UnmodifyModal';
 import ConfirmDeleteModal from './modal/ConfirmDeleteModal';
 import CompleteDeleteModal from './modal/CompleteDeleteModal';

--- a/grass-diary/src/pages/Diary/modal/ConfirmDeleteModal.jsx
+++ b/grass-diary/src/pages/Diary/modal/ConfirmDeleteModal.jsx
@@ -1,5 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
-import Button from '../../../components/Button';
+import Button from '@components/Button';
 
 const styles = stylex.create({
   background: {

--- a/grass-diary/src/pages/Intro/Intro.jsx
+++ b/grass-diary/src/pages/Intro/Intro.jsx
@@ -1,4 +1,4 @@
-import Header from '../../components/Header';
+import Header from '@components/Header';
 import {
   Container,
   Section,

--- a/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
+++ b/grass-diary/src/pages/Intro/LoginModal/LoginModal.jsx
@@ -1,5 +1,5 @@
 import stylex from '@stylexjs/stylex';
-import googleButton from '../../../assets/loginButton/googleButton.png';
+import googleButton from '@assets/loginButton/googleButton.png';
 
 const styles = stylex.create({
   container: {

--- a/grass-diary/src/pages/Intro/introComponents.jsx
+++ b/grass-diary/src/pages/Intro/introComponents.jsx
@@ -1,11 +1,11 @@
 import stylex from '@stylexjs/stylex';
 import styles from './styles';
-import grassDiary from '../../assets/icon/grassDiary.png';
-import Button from '../../components/Button';
+import grassDiary from '@assets/icon/grassDiary.png';
+import Button from '@components/Button';
 import LoginModal from './LoginModal/LoginModal';
-import useModal from '../../hooks/useModal';
+import useModal from '@hooks/useModal';
 
-import { checkAuth } from '../../utils/authUtils';
+import { checkAuth } from '@utils/authUtils';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/grass-diary/src/pages/Main/Main.jsx
+++ b/grass-diary/src/pages/Main/Main.jsx
@@ -1,15 +1,16 @@
-import * as stylex from '@stylexjs/stylex';
-import AnimateReward from './AnimateReward';
+import stylex from '@stylexjs/stylex';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import API from '../../services/index';
-import mainCharacter from '../../assets/icon/mainCharacter.png';
-import Header from '../../components/Header';
 import Swal from 'sweetalert2';
 import dayjs from 'dayjs';
-import { checkAuth } from '../../utils/authUtils';
-import useUser from '../../hooks/useUser';
-import Top10Feed from '../../components/Top10Feed';
+
+import API from '@services';
+import mainCharacter from '@assets/icon/mainCharacter.png';
+import { checkAuth } from '@utils/authUtils';
+import useUser from '@hooks/useUser';
+import Top10Feed from '@components/Top10Feed';
+import Header from '@components/Header';
+import AnimateReward from './AnimateReward';
 
 const styles = stylex.create({
   title: {

--- a/grass-diary/src/pages/MyPage/Diary.jsx
+++ b/grass-diary/src/pages/MyPage/Diary.jsx
@@ -4,10 +4,10 @@ import DOMPurify from 'dompurify';
 import { Link } from 'react-router-dom';
 import { useState } from 'react';
 
-import useUser from '../../hooks/useUser';
-import useDiary from '../../hooks/useDiary';
-import NormalLike from '../../components/NormalLike';
-import MoodProfile from '../../components/MoodProfile';
+import useUser from '@hooks/useUser';
+import useDiary from '@hooks/useDiary';
+import NormalLike from '@components/NormalLike';
+import MoodProfile from '@components/MoodProfile';
 
 const Pagination = ({ pageSize, onPageChange }) => {
   return (

--- a/grass-diary/src/pages/MyPage/Grass.jsx
+++ b/grass-diary/src/pages/MyPage/Grass.jsx
@@ -1,11 +1,11 @@
 import stylex from '@stylexjs/stylex';
 import styles from './style';
 import { useEffect, useState } from 'react';
-import { formatDate } from '../../utils/dateUtils';
-import { getDaysArray } from '../../utils/dateUtils';
-import useGrass from '../../hooks/ussGrass';
-import API from '../../services';
-import useUser from '../../hooks/useUser';
+
+import { formatDate, getDaysArray } from '@utils/dateUtils';
+import useGrass from '@hooks/ussGrass';
+import useUser from '@hooks/useUser';
+import API from '@services';
 
 const createGrass = () => {
   const year = new Date().getFullYear();

--- a/grass-diary/src/pages/MyPage/MyPage.jsx
+++ b/grass-diary/src/pages/MyPage/MyPage.jsx
@@ -1,4 +1,4 @@
-import Header from '../../components/Header';
+import Header from '@components/Header';
 import { Container, MainContainer } from './myComponents';
 
 const MyPage = () => {

--- a/grass-diary/src/pages/MyPage/myComponents.jsx
+++ b/grass-diary/src/pages/MyPage/myComponents.jsx
@@ -3,12 +3,12 @@ import styles from './style';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import Button from '../../components/Button';
-import { EllipsisBox, EllipsisIcon } from '../../components/Ellipsis';
-import Profile from '../../components/Profile';
-import useProfile from '../../hooks/useProfile';
 import Grass from './Grass';
 import Diary from './Diary';
+import Button from '@components/Button';
+import { EllipsisBox, EllipsisIcon } from '@components/Ellipsis';
+import Profile from '@components/Profile';
+import useProfile from '@hooks/useProfile';
 
 const Container = ({ children }) => {
   return <div {...stylex.props(styles.container)}>{children}</div>;

--- a/grass-diary/src/pages/Setting/Setting.jsx
+++ b/grass-diary/src/pages/Setting/Setting.jsx
@@ -1,11 +1,12 @@
-import stylex from '@stylexjs/stylex';
-import Header from '../../components/Header';
-import Profile from '../../components/Profile';
-import Button from '../../components/Button';
 import styles from './styles';
-import API from '../../services';
+import stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
-import useProfile from '../../hooks/useProfile';
+
+import API from '@services';
+import Header from '@components/Header';
+import Profile from '@components/Profile';
+import Button from '@components/Button';
+import useProfile from '@hooks/useProfile';
 
 const SettingSection = ({ children, label }) => {
   return (

--- a/grass-diary/src/pages/Share/Share.jsx
+++ b/grass-diary/src/pages/Share/Share.jsx
@@ -1,9 +1,10 @@
+import stylex from '@stylexjs/stylex';
 import { useEffect, useRef, useState } from 'react';
-import * as stylex from '@stylexjs/stylex';
-import Header from '../../components/Header';
-import Feed from '../../components/Feed';
-import Top10Feed from '../../components/Top10Feed';
-import API from '../../services';
+
+import API from '@services';
+import Feed from '@components/Feed';
+import Header from '@components/Header';
+import Top10Feed from '@components/Top10Feed';
 
 const styles = stylex.create({
   container: {

--- a/grass-diary/src/services/index.js
+++ b/grass-diary/src/services/index.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { clearAuth } from '../utils/authUtils';
+import { clearAuth } from '@utils/authUtils';
 
 const API_URI = import.meta.env.VITE_API_URI;
 

--- a/grass-diary/vite.config.js
+++ b/grass-diary/vite.config.js
@@ -1,10 +1,22 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import styleX from 'vite-plugin-stylex';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react(), styleX()],
   server: {
     port: 3000,
+  },
+  resolve: {
+    alias: {
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@constants': path.resolve(__dirname, 'src/constants'),
+      '@hooks': path.resolve(__dirname, 'src/hooks'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@services': path.resolve(__dirname, 'src/services'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
+      '@assets': path.resolve(__dirname, 'src/assets'),
+    },
   },
 });


### PR DESCRIPTION
## 절대 경로 설정 (CLIENT-103)

### 🔎 AS-IS

- 현재 import 경로가 깊어지고, 파일이 많아지면서 가독성이 떨어지고 있습니다.

### ✨ TO-BE

- [x] `jsconfig.paths.json` 및 `jsconfig.json` 파일을 생성한다.
  - [x] 절대 경로 관련 설정을 작성한다.
  > [https://velog.io/@rkio/React-절대-경로-커스텀하기](https://velog.io/@rkio/React-%EC%A0%88%EB%8C%80-%EA%B2%BD%EB%A1%9C-%EC%BB%A4%EC%8A%A4%ED%85%80%ED%95%98%EA%B8%B0)
- [x] vite.config.js 파일에서 경로 별칭을 매핑한다.
- [x] 각 파일에 설정한 절대 경로의 별칭을 적용한다.