### PR TITLE
:hammer: fix: 액세스 토큰 만료 시 자동으로 로그아웃되지 않는 버그 수정

### DIFF
--- a/grass-diary/src/services/index.js
+++ b/grass-diary/src/services/index.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import useLogout from '@hooks/useLogout';
 
 const API_URI = import.meta.env.VITE_API_URI;
 
@@ -21,10 +20,9 @@ API.interceptors.request.use(
 API.interceptors.response.use(
   response => response,
   error => {
-    const clearAuth = useLogout();
-
     if (error.response && error.response.status === 500) {
-      clearAuth();
+      localStorage.removeItem('accessToken');
+      window.location.href = '/';
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## 액세스 토큰 만료 시 자동으로 로그아웃되지 않는 버그 수정 (CLIENT-108)

### 🔎 AS-IS

- 현재 로그인한 사용자의 액세스 토큰이 만료되어도 자동으로 로그아웃되지 않고 있습니다. 따라서 Axios 응답 interceptor 관련 로직 변경이 필요합니다.

### 🔨TO-BE

- [x] interceptor 내부에서 호출해 사용 중인 useLogout hook 로직을 삭제하고, 직접 인증 상태를 관리하는 로직을 구현한다.

### 👀 문제 원인

- Axios Interceptor는 React의 렌더링 사이클과 독립적으로 작동하기 때문에, 직접적으로 React 훅을 호출하는 것은 설계 원칙에 위반됩니다. 따라서 Interceptor 내부에서 직접 인증 상태를 관리하는 로직을 구현해야 합니다. (useLogout hook 삭제 후 직접 인증 상태 구현하는 방향으로 로직 변경)