### PR TITLE
:recycle: refactor: 설정 페이지 저장 버튼 통합 (CLIENT-109)

### DIFF
--- a/grass-diary/src/pages/Setting/Setting.jsx
+++ b/grass-diary/src/pages/Setting/Setting.jsx
@@ -21,8 +21,7 @@ const Setting = () => {
   const { nickName, profileIntro } = useProfile();
 
   const [profile, setProfile] = useRecoilState(profileAtom);
-  const [clickedNameSave, setClickedNameSave] = useState(false);
-  const [clickedIntroSave, setClickedIntroSave] = useState(false);
+  const [clickedProfileSave, setClickedProfileSave] = useState(false);
 
   const handleChangeNickname = event => {
     setProfile({ ...profile, nickname: event.target.value });
@@ -36,29 +35,22 @@ const Setting = () => {
     setter(true);
   };
 
-  useEffect(() => {
-    if (clickedNameSave) {
-      API.patch('/members/me', { nickname: profile.nickname })
-        .then(() => {
-          setClickedNameSave(false);
-        })
-        .catch(error => {
-          console.error(`사용자 정보를 수정할 수 없습니다. ${error}`);
-        });
-    }
-  }, [clickedNameSave, profile.nickname]);
+  const profileInfo = {
+    nickname: profile.nickname,
+    profileIntro: profile.profileIntro,
+  };
 
   useEffect(() => {
-    if (clickedIntroSave) {
-      API.patch('/members/me', { profileIntro: profile.profileIntro })
+    if (clickedProfileSave) {
+      API.patch('/members/me', profileInfo)
         .then(() => {
-          setClickedIntroSave(false);
+          setClickedProfileSave(false);
         })
         .catch(error => {
           console.error(`사용자 정보를 수정할 수 없습니다. ${error}`);
         });
     }
-  }, [clickedIntroSave, profile.profileIntro]);
+  }, [clickedProfileSave, profile.nickname, profile.profileIntro]);
 
   return (
     <div {...stylex.props(styles.container)}>
@@ -86,14 +78,6 @@ const Setting = () => {
                 placeholder={nickName}
                 onChange={handleChangeNickname}
               ></input>
-              <Button
-                text="저장"
-                width="70px"
-                color="#000"
-                backgroundColor="#FFF"
-                border="2px solid #929292"
-                onClick={handleClick(setClickedNameSave)}
-              />
             </SettingSection>
             <SettingSection label="소개글">
               <textarea
@@ -101,19 +85,20 @@ const Setting = () => {
                 placeholder={profileIntro}
                 onChange={handleChangeProfileIntro}
               ></textarea>
-              <Button
-                text="저장"
-                width="70px"
-                height="51px"
-                color="#000"
-                backgroundColor="#FFF"
-                border="2px solid #929292"
-                onClick={handleClick(setClickedIntroSave)}
-              />
             </SettingSection>
             <SettingSection label="잔디색">
-              <div {...stylex.props(styles.colorWrapper)}>
-                <div {...stylex.props(styles.grassColor)}></div>
+              <div {...stylex.props(styles.saveSection)}>
+                <div {...stylex.props(styles.colorWrapper)}>
+                  <div {...stylex.props(styles.grassColor)}></div>
+                </div>
+                <Button
+                  text="저장"
+                  width="70px"
+                  color="#000"
+                  backgroundColor="#FFF"
+                  border="1px solid #BFBFBF"
+                  onClick={handleClick(setClickedProfileSave)}
+                />
               </div>
             </SettingSection>
           </div>

--- a/grass-diary/src/pages/Setting/styles.js
+++ b/grass-diary/src/pages/Setting/styles.js
@@ -83,13 +83,20 @@ const styles = stylex.create({
     padding,
   }),
 
+  saveSection: {
+    display: 'flex',
+    justifyContent: 'space-between',
+
+    width: '71%',
+  },
+
   colorWrapper: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
 
-    width: '2.9rem',
-    height: '2.9rem',
+    width: '3.1rem',
+    height: '3.1rem',
 
     border: '1px solid #BFBFBF',
     borderRadius: '100%',
@@ -97,8 +104,8 @@ const styles = stylex.create({
   },
 
   grassColor: {
-    width: '2rem',
-    height: '2rem',
+    width: '2.2rem',
+    height: '2.2rem',
 
     borderRadius: '100%',
     backgroundColor: '#84FF79',


### PR DESCRIPTION
## 설정 페이지 저장 버튼 통합 (CLIENT-109)
### 🔎 AS-IS

현재 설정 페이지의 저장 버튼이 닉네임과 소개글로 나뉘어져 있어, 사용자 경험(UX)이 좋지 않은 편입니다. 따라서 설정 페이지의 모든 변경 사항을 저장 버튼 한 개로 관리하고자 합니다.

### ♻️ TO-BE

- [x] 저장 버튼을 두 개에서 한 개로 변경하고, 버튼의 위치 또한 하단으로 변경한다. 
- [x] 저장 버튼을 눌렀을 시 닉네임 수정과 소개글 수정이 한 번에 반영되도록 변경한다.