### PR TITLE
♻️ refactor: Tanstack Query 적용 (마이 페이지 및 설정 페이지)

### DIFF
--- a/grass-diary/package-lock.json
+++ b/grass-diary/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@stylexjs/stylex": "^0.5.1",
+        "@tanstack/react-query": "^5.29.2",
         "axios": "^1.6.7",
         "dayjs": "^1.11.10",
         "dompurify": "^3.0.11",
@@ -4569,6 +4570,30 @@
         "invariant": "^2.2.4",
         "styleq": "0.1.3",
         "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.29.0.tgz",
+      "integrity": "sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
+      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.29.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/grass-diary/package.json
+++ b/grass-diary/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.5.1",
+    "@tanstack/react-query": "^5.29.2",
     "axios": "^1.6.7",
     "dayjs": "^1.11.10",
     "dompurify": "^3.0.11",

--- a/grass-diary/src/hooks/useDiary.js
+++ b/grass-diary/src/hooks/useDiary.js
@@ -1,27 +1,28 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import API from '@services';
 
-const useDiary = (memberId, currentPage, sortOrder) => {
-  const [diaryList, setDiaryList] = useState([]);
-  const [pageSize, setPageSize] = useState(0);
+const useDiary = ({ memberId, currentPage, sortOrder }) => {
+  const queryKey = ['diaryList', { memberId, currentPage, sortOrder }];
 
-  useEffect(() => {
+  const queryFn = async () => {
     let apiUrl = `/diary/main/${memberId}?page=${currentPage}`;
-    if (sortOrder === 'oldest') {
-      apiUrl += `&sort=createdAt,ASC`;
-    }
 
-    if (memberId) {
-      API.get(apiUrl)
-        .then(response => {
-          setPageSize(response.data.totalPages);
-          setDiaryList(response.data.content);
-        })
-        .catch(error => {
-          console.error(`사용자의 일기를 조회할 수 없습니다. ${error}`);
-        });
-    }
-  }, [memberId, sortOrder, currentPage]);
+    if (sortOrder === 'oldest') apiUrl += `&sort=createdAt,ASC`;
+    const response = await API.get(apiUrl);
+
+    return response.data;
+  };
+
+  const { data: diary } = useQuery({
+    queryKey,
+    queryFn,
+    enabled: !!memberId,
+    onError: error =>
+      console.error(`사용자의 일기를 조회할 수 없습니다. ${error}`),
+  });
+
+  const diaryList = diary?.content || [];
+  const pageSize = diary?.totalPages || 0;
 
   return { diaryList, pageSize };
 };

--- a/grass-diary/src/main.jsx
+++ b/grass-diary/src/main.jsx
@@ -4,13 +4,18 @@ import { RecoilRoot } from 'recoil';
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import './styles/reset.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RecoilRoot>
-      <Suspense>
-        <RouterProvider router={router} />
-      </Suspense>
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <Suspense>
+          <RouterProvider router={router} />
+        </Suspense>
+      </RecoilRoot>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/grass-diary/src/pages/CreateDiary/QuillEditor.jsx
+++ b/grass-diary/src/pages/CreateDiary/QuillEditor.jsx
@@ -4,7 +4,7 @@ import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
 const QuillEditor = ({ onContentChange, quillContent }) => {
-  const handleChange = editor => {
+  const handleChange = (content, delta, source, editor) => {
     onContentChange(editor.getHTML());
   };
 

--- a/grass-diary/src/pages/MyPage/Diary.jsx
+++ b/grass-diary/src/pages/MyPage/Diary.jsx
@@ -54,7 +54,11 @@ const DiaryItem = ({ diary, diaryList, index }) => {
 const Diary = ({ searchTerm, sortOrder, selectedDiary }) => {
   const { memberId } = useUser();
   const [currentPage, setCurrentPage] = useState(0);
-  const { diaryList, pageSize } = useDiary(memberId, currentPage, sortOrder);
+  const { diaryList, pageSize } = useDiary({
+    memberId,
+    currentPage,
+    sortOrder,
+  });
 
   const filteredDiaryList =
     selectedDiary && selectedDiary.diaryId

--- a/grass-diary/src/pages/MyPage/Grass.jsx
+++ b/grass-diary/src/pages/MyPage/Grass.jsx
@@ -1,6 +1,7 @@
 import stylex from '@stylexjs/stylex';
 import styles from './style';
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { formatDate, getDaysArray } from '@utils/dateUtils';
 import useGrass from '@hooks/ussGrass';
@@ -36,26 +37,31 @@ const Grass = ({ setSelectedDiary }) => {
     setSelectedGrass(formatDate(date));
   };
 
-  useEffect(() => {
-    if (selectedGrass) {
-      const selectedDate = `${year}-${selectedGrass.split('/').join('-')}`;
+  const selectedDate = selectedGrass
+    ? `${year}-${selectedGrass.split('/').join('-')}`
+    : null;
 
-      API.get(`/search/date/${memberId}?date=${selectedDate}`)
-        .then(response => {
-          setSelectedDiary(response.data);
-        })
-        .catch(error => {
-          console.error(error);
-        });
-    }
-  }, [selectedGrass, memberId, setSelectedDiary, year]);
+  const { data: selectedDiary } = useQuery({
+    queryKey: ['selectedDiary', memberId, selectedDate],
+    queryFn: () =>
+      API.get(`/search/date/${memberId}?date=${selectedDate}`).then(
+        ({ data }) => data,
+      ),
+    enabled: !!selectedGrass && !!memberId,
+    onError: error =>
+      console.error(`선택된 날짜의 일기를 불러올 수 없습니다. ${error}`),
+  });
+
+  useEffect(() => {
+    if (selectedDiary) setSelectedDiary(selectedDiary);
+    if (!selectedDiary) setSelectedDiary([]);
+  }, [selectedDiary]);
 
   return (
     <div {...stylex.props(styles.grassContainer)}>
       {grass.map((column, index) => (
         <div key={index} {...stylex.props(styles.grass)}>
           {column.map((day, index) => {
-            if (day === null) return null;
             const writeDay = formatDate(day);
             return (
               <div key={index} {...stylex.props(styles.dayContainer)}>

--- a/grass-diary/src/pages/MyPage/Grass.jsx
+++ b/grass-diary/src/pages/MyPage/Grass.jsx
@@ -30,7 +30,7 @@ const Grass = ({ setSelectedDiary }) => {
   const [selectedGrass, setSelectedGrass] = useState(null);
   const { year, grass } = createGrass();
   const { memberId } = useUser();
-  const grassColors = useGrass();
+  const grassColors = useGrass(memberId);
 
   const handleGrassClick = date => {
     setSelectedGrass(formatDate(date));
@@ -59,17 +59,19 @@ const Grass = ({ setSelectedDiary }) => {
             const writeDay = formatDate(day);
             return (
               <div key={index} {...stylex.props(styles.dayContainer)}>
-                <div
-                  onClick={() => handleGrassClick(day)}
-                  {...stylex.props(
-                    styles.grassDate(
-                      writeDay === selectedGrass ? '1px solid black' : 'none',
-                      grassColors[writeDay]
-                        ? `rgba(${grassColors[writeDay]})`
-                        : '#E0E0E0',
-                    ),
-                  )}
-                ></div>
+                {grassColors && (
+                  <div
+                    onClick={() => handleGrassClick(day)}
+                    {...stylex.props(
+                      styles.grassDate(
+                        writeDay === selectedGrass ? '1px solid black' : 'none',
+                        grassColors[writeDay]
+                          ? `rgba(${grassColors[writeDay]})`
+                          : '#E0E0E0',
+                      ),
+                    )}
+                  ></div>
+                )}
                 {formatDate(day) === selectedGrass && (
                   <div {...stylex.props(styles.dateBubble)}>
                     <span>{selectedGrass}</span>


### PR DESCRIPTION
## 🔎 작업 내용 

> 아래 페이지 내 기능들에 `tanstack query` 적용

- [x] tanstack query 설치 및 `QueryClientProvider` 추가
- [x] 마이 페이지
  - [x] 사용자가 작성한 일기 조회
  - [x] 사용자의 연간 잔디
  - [x] 연간 잔디 날짜 선택 시 선택된 날짜에 해당하는 일기 조회
 - [x] 설정 페이지
   - [x] 사용자 정보 수정

## 📚 설명

- 예기치 못한 문제 발생 예방을 위해 useEffect 내부에서 서버와 통신하던 방식에서, `tanstack query`를 적용해 변경해 주었습니다.

issue: #88 