### PR TITLE
🔨fix: Feed 컴포넌트, 일기 내용 html 태그 적용 문제 해결 

### DIFF
--- a/grass-diary/src/components/Feed/Feed.jsx
+++ b/grass-diary/src/components/Feed/Feed.jsx
@@ -1,6 +1,5 @@
 import stylex from '@stylexjs/stylex';
 import { Link } from 'react-router-dom';
-import DOMPurify from 'dompurify';
 import { NormalLike } from '@components';
 
 const feed = stylex.create({
@@ -46,12 +45,19 @@ const feed = stylex.create({
 });
 
 const Feed = ({ likeCount, link, title, content, name, profile }) => {
-  const createMarkup = htmlContent => {
-    return { __html: DOMPurify.sanitize(htmlContent) };
+  const extractTextFromHTML = htmlString => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlString, 'text/html');
+
+    return doc.body.textContent || '';
   };
 
-  const processedContent =
-    content && content.length > 350 ? `${content.slice(0, 350)}...` : content;
+  const textWithoutTags = () => {
+    if (content && content.length > 210) {
+      return `${extractTextFromHTML(content).slice(0, 210)}...`;
+    }
+    return extractTextFromHTML(content);
+  };
 
   return (
     <Link to={link}>
@@ -63,10 +69,7 @@ const Feed = ({ likeCount, link, title, content, name, profile }) => {
         </div>
 
         <div {...stylex.props(feed.title)}>{title}</div>
-        <div
-          {...stylex.props(feed.content)}
-          dangerouslySetInnerHTML={createMarkup(processedContent)}
-        />
+        <div {...stylex.props(feed.content)}>{textWithoutTags()}</div>
       </article>
     </Link>
   );


### PR DESCRIPTION
# 🔎 작업 내용
- [x] 피드 내 일기 내용 텍스트는 좌측 정렬로만 보여지도록 한다.
### 작업 전
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/cab902e4-fe95-415c-b8e6-b7e04034dce2)
### 작업 후
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/d86b4f80-44d5-4325-a91a-31577073cdef)
 
# 📚 reference
[React-quill 에서 작성한 데이터 렌더링 ( 태그 벗겨내기)](https://velog.io/@as13ljh/React-quill-%EC%97%90%EC%84%9C-%EC%9E%91%EC%84%B1%ED%95%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%A0%8C%EB%8D%94%EB%A7%81-%ED%83%9C%EA%B7%B8-%EB%B2%97%EA%B2%A8%EB%82%B4%EA%B8%B0)

issue: #91 