### PR TITLE
✨ feat: 소개 페이지 react-fullpage 적용

### DIFF
--- a/grass-diary/package-lock.json
+++ b/grass-diary/package-lock.json
@@ -8,6 +8,7 @@
       "name": "grass-diary",
       "version": "0.0.0",
       "dependencies": {
+        "@fullpage/react-fullpage": "^0.1.42",
         "@stylexjs/stylex": "^0.5.1",
         "@tanstack/react-query": "^5.29.2",
         "axios": "^1.6.7",
@@ -1850,6 +1851,21 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
+      "dependencies": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/@babel/preset-env": {
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.0.tgz",
@@ -2514,6 +2530,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fullpage/react-fullpage": {
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/@fullpage/react-fullpage/-/react-fullpage-0.1.42.tgz",
+      "integrity": "sha512-VgkjUKj8JZXaBaasrJPTn6x9TF1EEx9u/a724ANlEwf8vTCd7yiuz36LBvBIr0U6NTFCp+EqhmjXQkzZ4R3Iig==",
+      "dependencies": {
+        "@babel/polyfill": "^7.2.5",
+        "fullpage.js": "^4.0.22"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -5843,6 +5868,13 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
+    },
     "node_modules/core-js-compat": {
       "version": "3.36.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.0.tgz",
@@ -7036,6 +7068,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/fullpage.js": {
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/fullpage.js/-/fullpage.js-4.0.22.tgz",
+      "integrity": "sha512-8CCRrL8DwoFIDcBifvB0YfZZV63vUjairLsBX/uuOSsFa3gPS1Or4bLm2llFojL091MINMPzwdzTgbIO5iDdKw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/grass-diary/package.json
+++ b/grass-diary/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fullpage/react-fullpage": "^0.1.42",
     "@stylexjs/stylex": "^0.5.1",
     "@tanstack/react-query": "^5.29.2",
     "axios": "^1.6.7",

--- a/grass-diary/src/components/Container.tsx
+++ b/grass-diary/src/components/Container.tsx
@@ -1,0 +1,15 @@
+import stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+});
+
+const Container = ({ children }: IContainer) => {
+  return <div {...stylex.props(styles.container)}>{children}</div>;
+};
+
+export default Container;

--- a/grass-diary/src/components/Container.tsx
+++ b/grass-diary/src/components/Container.tsx
@@ -5,6 +5,8 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+
+    gap: '10px',
   },
 });
 

--- a/grass-diary/src/components/Header.tsx
+++ b/grass-diary/src/components/Header.tsx
@@ -7,11 +7,12 @@ import useLogout from '@hooks/useLogout';
 import useUser from '@recoil/user/useUser';
 
 const header = stylex.create({
-  container: (position?: string, margin?: string) => ({
+  container: (position?: string) => ({
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'center',
     padding: '20px 20px',
-    height: '80px',
+
     width: {
       default: '1140px',
       '@media (max-width: 1139px)': '100vw',
@@ -19,8 +20,16 @@ const header = stylex.create({
     zIndex: '10',
 
     position,
-    margin,
   }),
+
+  itemWrapper: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+
+    width: '100%',
+  },
+
   logo: {
     cursor: 'pointer',
     fontSize: '18px',
@@ -148,23 +157,25 @@ const Header = ({ position, margin }: THeader) => {
 
   return (
     <div {...stylex.props(header.container(position, margin))}>
-      <Link to="/main">
-        <span {...stylex.props(header.logo)}>잔디일기</span>
-      </Link>
-      {memberId ? (
-        <div {...stylex.props(header.userMenu)} onClick={dropDown}>
-          <div ref={profileRef}>
-            <Profile width="44px" height="44px" />
+      <div {...stylex.props(header.itemWrapper)}>
+        <Link to="/main">
+          <span {...stylex.props(header.logo)}>잔디일기</span>
+        </Link>
+        {memberId ? (
+          <div {...stylex.props(header.userMenu)} onClick={dropDown}>
+            <div ref={profileRef}>
+              <Profile width="44px" height="44px" />
+            </div>
+            <div
+              {...stylex.props(header.arrowUp, toggle && header.arrowDown)}
+              ref={iconRef}
+            >
+              <i className="fa-solid fa-angle-down"></i>
+            </div>
+            <MenuBar headerRef={headerRef} toggle={toggle} />
           </div>
-          <div
-            {...stylex.props(header.arrowUp, toggle && header.arrowDown)}
-            ref={iconRef}
-          >
-            <i className="fa-solid fa-angle-down"></i>
-          </div>
-          <MenuBar headerRef={headerRef} toggle={toggle} />
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/grass-diary/src/components/Header.tsx
+++ b/grass-diary/src/components/Header.tsx
@@ -32,7 +32,8 @@ const header = stylex.create({
 
   logo: {
     cursor: 'pointer',
-    fontSize: '18px',
+    fontSize: '22px',
+    fontWeight: '500',
   },
   userMenu: {
     zIndex: '1',

--- a/grass-diary/src/components/Header.tsx
+++ b/grass-diary/src/components/Header.tsx
@@ -7,17 +7,20 @@ import useLogout from '@hooks/useLogout';
 import useUser from '@recoil/user/useUser';
 
 const header = stylex.create({
-  container: {
+  container: (position?: string, margin?: string) => ({
     display: 'flex',
     alignItems: 'center',
-    padding: '0 20px',
+    padding: '20px 20px',
     height: '80px',
-    margin: 'auto',
     width: {
       default: '1140px',
       '@media (max-width: 1139px)': '100vw',
     },
-  },
+    zIndex: '10',
+
+    position,
+    margin,
+  }),
   logo: {
     cursor: 'pointer',
     fontSize: '18px',
@@ -111,7 +114,12 @@ const MenuBar = ({ toggle, headerRef }) => {
   );
 };
 
-const Header = () => {
+type THeader = {
+  position?: string;
+  margin?: string;
+};
+
+const Header = ({ position, margin }: THeader) => {
   const [toggle, setToggle] = useState(false);
   const headerRef = useRef();
   const iconRef = useRef();
@@ -139,7 +147,7 @@ const Header = () => {
   }, [memberId, toggle]);
 
   return (
-    <div {...stylex.props(header.container)}>
+    <div {...stylex.props(header.container(position, margin))}>
       <Link to="/main">
         <span {...stylex.props(header.logo)}>잔디일기</span>
       </Link>

--- a/grass-diary/src/components/index.ts
+++ b/grass-diary/src/components/index.ts
@@ -8,4 +8,5 @@ export { default as Top10Feed } from './Feed/Top10Feed';
 export { default as Profile } from './Profile/Profile';
 export { default as MoodProfile } from './Profile/MoodProfile';
 export { default as ProtectedRoute } from './ProtectedRoute';
+export { default as Container } from './Container';
 export { EllipsisIcon, EllipsisBox } from './Ellipsis';

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -7,7 +7,7 @@ import QuillEditor from './QuillEditor';
 
 import API from '@services/index';
 import useUser from '@recoil/user/useUser';
-import { Header, BackButton, Button } from '@components/index';
+import { Header, BackButton, Button, Container } from '@components/index';
 import EMOJI from '@constants/emoji';
 import 'dayjs/locale/ko';
 
@@ -253,9 +253,9 @@ const CreateDiary = () => {
   }, []);
 
   return (
-    <>
+    <Container>
       <header>
-        <Header margin="auto" />
+        <Header />
       </header>
       <main {...stylex.props(CreateDiaryStyle.container)}>
         <BackButton link={'/main'} />
@@ -345,7 +345,7 @@ const CreateDiary = () => {
           </div>
         </section>
       </main>
-    </>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -255,7 +255,7 @@ const CreateDiary = () => {
   return (
     <>
       <header>
-        <Header />
+        <Header margin="auto" />
       </header>
       <main {...stylex.props(CreateDiaryStyle.container)}>
         <BackButton link={'/main'} />

--- a/grass-diary/src/pages/Diary/Diary.tsx
+++ b/grass-diary/src/pages/Diary/Diary.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 
-import { Header, BackButton, Like } from '@components/index';
+import { Header, BackButton, Like, Container } from '@components/index';
 import API from '@services/index';
 import useUser from '@recoil/user/useUser';
 import EMOJI from '@constants/emoji';
@@ -154,8 +154,8 @@ const Diary = () => {
   };
 
   return (
-    <>
-      <Header margin="auto" />
+    <Container>
+      <Header />
       <div {...stylex.props(styles.wrap)}>
         <BackButton />
         {/* 일기 타이틀  */}
@@ -214,7 +214,7 @@ const Diary = () => {
           </div>
         </div>
       </div>
-    </>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/Diary/Diary.tsx
+++ b/grass-diary/src/pages/Diary/Diary.tsx
@@ -155,7 +155,7 @@ const Diary = () => {
 
   return (
     <>
-      <Header />
+      <Header margin="auto" />
       <div {...stylex.props(styles.wrap)}>
         <BackButton />
         {/* 일기 타이틀  */}

--- a/grass-diary/src/pages/Diary/NonExistentDiary.tsx
+++ b/grass-diary/src/pages/Diary/NonExistentDiary.tsx
@@ -16,7 +16,7 @@ const styles = stylex.create({
 const NonExistentDiary = () => {
   return (
     <>
-      <Header />
+      <Header margin="auto" />
       <div {...stylex.props(styles.wrap)}>
         <BackButton goBackTo={'/main'} />
         <div {...stylex.props(styles.content)}>

--- a/grass-diary/src/pages/Diary/NonExistentDiary.tsx
+++ b/grass-diary/src/pages/Diary/NonExistentDiary.tsx
@@ -1,5 +1,5 @@
 import stylex from '@stylexjs/stylex';
-import { Header, BackButton } from '@components/index';
+import { Header, BackButton, Container } from '@components/index';
 
 const styles = stylex.create({
   wrap: {
@@ -15,15 +15,15 @@ const styles = stylex.create({
 
 const NonExistentDiary = () => {
   return (
-    <>
-      <Header margin="auto" />
+    <Container>
+      <Header />
       <div {...stylex.props(styles.wrap)}>
         <BackButton goBackTo={'/main'} />
         <div {...stylex.props(styles.content)}>
           <p>존재하지 않는 일기입니다❗</p>
         </div>
       </div>
-    </>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/Intro/Intro.tsx
+++ b/grass-diary/src/pages/Intro/Intro.tsx
@@ -1,30 +1,38 @@
 import { Header } from '@components/index';
 import {
-  Container,
-  Section,
   ServiceMain,
   MainDesc,
   SecondDesc,
   StartContent,
 } from './introComponents';
+import ReactFullpage from '@fullpage/react-fullpage';
 
 const Intro = () => {
   return (
-    <Container>
-      <Header />
-      <Section backgroundColor="#FEFEFE" height="90vh">
-        <ServiceMain />
-      </Section>
-      <Section backgroundColor="#F9FFF7" height="100vh">
-        <MainDesc />
-      </Section>
-      <Section backgroundColor="#F0FFEA" height="100vh">
-        <SecondDesc />
-      </Section>
-      <Section backgroundColor="#E1FFD7" height="100vh">
-        <StartContent />
-      </Section>
-    </Container>
+    <>
+      <Header position="fixed" margin="0 10.3rem" />
+      <ReactFullpage
+        scrollingSpeed={1000}
+        render={({ state }) => {
+          return (
+            <ReactFullpage.Wrapper>
+              <div className="section" style={{ backgroundColor: '#FEFEFE' }}>
+                <ServiceMain />
+              </div>
+              <div className="section" style={{ backgroundColor: '#F9FFF7' }}>
+                <MainDesc />
+              </div>
+              <div className="section" style={{ backgroundColor: '#F0FFEA' }}>
+                <SecondDesc />
+              </div>
+              <div className="section" style={{ backgroundColor: '#E1FFD7' }}>
+                <StartContent />
+              </div>
+            </ReactFullpage.Wrapper>
+          );
+        }}
+      />
+    </>
   );
 };
 

--- a/grass-diary/src/pages/Intro/Intro.tsx
+++ b/grass-diary/src/pages/Intro/Intro.tsx
@@ -1,4 +1,4 @@
-import { Header } from '@components/index';
+import { Container, Header } from '@components/index';
 import {
   ServiceMain,
   MainDesc,
@@ -10,7 +10,9 @@ import ReactFullpage from '@fullpage/react-fullpage';
 const Intro = () => {
   return (
     <>
-      <Header position="fixed" margin="0 10.3rem" />
+      <Container>
+        <Header position="fixed" />
+      </Container>
       <ReactFullpage
         scrollingSpeed={1000}
         render={({ state }) => {

--- a/grass-diary/src/pages/Intro/introComponents.tsx
+++ b/grass-diary/src/pages/Intro/introComponents.tsx
@@ -6,7 +6,7 @@ import { NavigateFunction, useNavigate } from 'react-router-dom';
 import LoginModal from './LoginModal/LoginModal';
 import grassDiary from '@icon/grassDiary.png';
 import useModal from '@hooks/useModal';
-import { Button } from '@components/index';
+import { Button, Container } from '@components/index';
 import { checkAuth } from '@utils/authUtils';
 import introDiaryImage from '@icon/introDiaryImage.png';
 import mainCharacter from '@icon/mainCharacter.png';
@@ -55,7 +55,7 @@ const OpenModalButton = () => {
 
 const ServiceMain = () => {
   return (
-    <div {...stylex.props(styles.container)}>
+    <Container>
       <div {...stylex.props(styles.mainContent('row'))}>
         <div {...stylex.props(styles.mainDescription())}>
           <h1 {...stylex.props(styles.mainTitle)}>잔디 일기</h1>
@@ -78,13 +78,13 @@ const ServiceMain = () => {
           <img src={grassDiary} alt="잔디 다이어리" />
         </div>
       </div>
-    </div>
+    </Container>
   );
 };
 
 const MainDesc = () => {
   return (
-    <div {...stylex.props(styles.container)}>
+    <Container>
       <div {...stylex.props(styles.mainContent('row'))}>
         <img
           {...stylex.props(styles.contentImage('35rem', '35rem'))}
@@ -103,13 +103,13 @@ const MainDesc = () => {
           </p>
         </div>
       </div>
-    </div>
+    </Container>
   );
 };
 
 const SecondDesc = () => {
   return (
-    <div {...stylex.props(styles.container)}>
+    <Container>
       <div {...stylex.props(styles.mainContent('column'))}>
         <div {...stylex.props(styles.mainDescription('center'))}>
           <h1>꾸준히 잔디를 심고 리워드를 획득해요</h1>
@@ -123,7 +123,7 @@ const SecondDesc = () => {
           alt="mainCharacter"
         />
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/Intro/introComponents.tsx
+++ b/grass-diary/src/pages/Intro/introComponents.tsx
@@ -55,18 +55,28 @@ const OpenModalButton = () => {
 
 const ServiceMain = () => {
   return (
-    <div {...stylex.props(styles.mainContent('row'))}>
-      <div {...stylex.props(styles.mainDescription())}>
-        <h1 {...stylex.props(styles.mainTitle)}>잔디 일기</h1>
-        <p {...stylex.props(styles.contentDesc('1.35rem'))}>
-          일상 속의 잔디, <br />
-          나의 이야기를 키우다
-        </p>
-        <p>일상의 작은 기록들이 잔디처럼 자라나 큰 성장으로 이어져요</p>
-        <OpenModalButton />
-      </div>
-      <div {...stylex.props(styles.mainImage)}>
-        <img src={grassDiary} alt="잔디 다이어리" />
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.mainContent('row'))}>
+        <div {...stylex.props(styles.mainDescription())}>
+          <h1 {...stylex.props(styles.mainTitle)}>잔디 일기</h1>
+          <p
+            {...stylex.props(
+              styles.contentDesc('1.35rem', '20px 0 0 0', '400'),
+            )}
+          >
+            일상 속의 잔디,
+          </p>
+          <p {...stylex.props(styles.contentDesc('1.35rem', '0', '400'))}>
+            나의 이야기를 키우다
+          </p>
+          <p {...stylex.props(styles.contentDesc('1rem', '25px 0 15px 0'))}>
+            일상의 작은 기록들이 잔디처럼 자라나 큰 성장으로 이어져요
+          </p>
+          <OpenModalButton />
+        </div>
+        <div {...stylex.props(styles.mainImage)}>
+          <img src={grassDiary} alt="잔디 다이어리" />
+        </div>
       </div>
     </div>
   );
@@ -74,25 +84,24 @@ const ServiceMain = () => {
 
 const MainDesc = () => {
   return (
-    <div {...stylex.props(styles.mainContent('row'))}>
-      <img
-        {...stylex.props(styles.contentImage('35rem', '35rem'))}
-        src={introDiaryImage}
-        alt="Section2Image"
-      />
-      <div {...stylex.props(styles.mainDescription())}>
-        <h1 {...stylex.props(styles.contentDesc('1.75rem'))}>
-          우리는
-          <br />
-          성장을 위해서
-          <br />
-          기록합니다
-        </h1>
-        <p>
-          변화와 성장이 함께하는
-          <br />
-          나만의 스토리를 완성할 수 있어요
-        </p>
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.mainContent('row'))}>
+        <img
+          {...stylex.props(styles.contentImage('35rem', '35rem'))}
+          src={introDiaryImage}
+          alt="Section2Image"
+        />
+        <div {...stylex.props(styles.mainDescription())}>
+          <h1>우리는</h1>
+          <h1>성장을 위해서</h1>
+          <h1>기록합니다</h1>
+          <p {...stylex.props(styles.contentDesc('1rem', '20px 0 0 0'))}>
+            변화와 성장이 함께하는
+          </p>
+          <p {...stylex.props(styles.contentDesc('1rem', '0'))}>
+            나만의 스토리를 완성할 수 있어요
+          </p>
+        </div>
       </div>
     </div>
   );
@@ -100,18 +109,20 @@ const MainDesc = () => {
 
 const SecondDesc = () => {
   return (
-    <div {...stylex.props(styles.mainContent('column'))}>
-      <div {...stylex.props(styles.mainDescription('center'))}>
-        <h1 {...stylex.props(styles.contentDesc('1.75rem'))}>
-          꾸준히 잔디를 심고 리워드를 획득해요
-        </h1>
-        <p>받은 리워드로 테마 상점에서 다양한 아이템을 만날 수 있어요</p>
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.mainContent('column'))}>
+        <div {...stylex.props(styles.mainDescription('center'))}>
+          <h1>꾸준히 잔디를 심고 리워드를 획득해요</h1>
+          <p {...stylex.props(styles.contentDesc('1rem', '15px 0 0 0'))}>
+            받은 리워드로 테마 상점에서 다양한 아이템을 만날 수 있어요
+          </p>
+        </div>
+        <img
+          {...stylex.props(styles.contentImage('28rem', '27rem'))}
+          src={mainCharacter}
+          alt="mainCharacter"
+        />
       </div>
-      <img
-        {...stylex.props(styles.contentImage('28rem', '27rem'))}
-        src={mainCharacter}
-        alt="mainCharacter"
-      />
     </div>
   );
 };
@@ -119,9 +130,7 @@ const SecondDesc = () => {
 const StartContent = () => {
   return (
     <div {...stylex.props(styles.mainDescription('center'))}>
-      <h1 {...stylex.props(styles.contentDesc('1.75rem'))}>
-        지금 바로 잔디 일기를 시작해 보세요!
-      </h1>
+      <h1>지금 바로 잔디 일기를 시작해 보세요!</h1>
       <OpenModalButton />
     </div>
   );

--- a/grass-diary/src/pages/Intro/introComponents.tsx
+++ b/grass-diary/src/pages/Intro/introComponents.tsx
@@ -11,24 +11,6 @@ import { checkAuth } from '@utils/authUtils';
 import introDiaryImage from '@icon/introDiaryImage.png';
 import mainCharacter from '@icon/mainCharacter.png';
 
-interface TSection {
-  backgroundColor: string;
-  height: string;
-  children: React.ReactNode;
-}
-
-type TStartButton = () => void;
-
-const Container = ({ children }: IContainer) => {
-  return <div {...stylex.props(styles.container)}>{children}</div>;
-};
-
-const Section = ({ backgroundColor, height, children }: TSection) => (
-  <section {...stylex.props(styles.mainContainer(backgroundColor, height))}>
-    {children}
-  </section>
-);
-
 const OpenModalButton = () => {
   const navigate: NavigateFunction = useNavigate();
   const { isModalOpen, handleOpenModal, handleCloseModal }: IModalReturn =
@@ -43,6 +25,8 @@ const OpenModalButton = () => {
 
     loggedIn();
   }, []);
+
+  type TStartButton = () => void;
 
   const handleStartButton: TStartButton = () => {
     if (isLoggedIn) navigate('/main');
@@ -143,4 +127,4 @@ const StartContent = () => {
   );
 };
 
-export { Container, Section, ServiceMain, MainDesc, SecondDesc, StartContent };
+export { ServiceMain, MainDesc, SecondDesc, StartContent };

--- a/grass-diary/src/pages/Intro/styles.ts
+++ b/grass-diary/src/pages/Intro/styles.ts
@@ -49,9 +49,12 @@ const styles = stylex.create({
     height,
   }),
 
-  contentDesc: (fontSize: string) => ({
-    marginBottom: '0.6rem',
+  contentDesc: (fontSize?: string, margin?: string, fontWeight?: string) => ({
+    lineHeight: '1.34',
+
+    fontWeight,
     fontSize,
+    margin,
   }),
 });
 

--- a/grass-diary/src/pages/Intro/styles.ts
+++ b/grass-diary/src/pages/Intro/styles.ts
@@ -3,23 +3,9 @@ import stylex from '@stylexjs/stylex';
 const styles = stylex.create({
   container: {
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
-
-    width: '100vw',
-    height: 'auto',
-  },
-
-  mainContainer: (backgroundColor: string, height: string) => ({
-    display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
-
-    width: '100%',
-
-    height,
-    backgroundColor,
-  }),
+  },
 
   mainDescription: (alignItems?: string) => ({
     display: 'flex',

--- a/grass-diary/src/pages/Intro/styles.ts
+++ b/grass-diary/src/pages/Intro/styles.ts
@@ -50,8 +50,6 @@ const styles = stylex.create({
   }),
 
   contentDesc: (fontSize?: string, margin?: string, fontWeight?: string) => ({
-    lineHeight: '1.34',
-
     fontWeight,
     fontSize,
     margin,

--- a/grass-diary/src/pages/Intro/styles.ts
+++ b/grass-diary/src/pages/Intro/styles.ts
@@ -1,12 +1,6 @@
 import stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  container: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-
   mainDescription: (alignItems?: string) => ({
     display: 'flex',
     flexDirection: 'column',

--- a/grass-diary/src/pages/Main/Main.tsx
+++ b/grass-diary/src/pages/Main/Main.tsx
@@ -581,7 +581,7 @@ const Main = () => {
 
   return (
     <>
-      <Header />
+      <Header margin="auto" />
       <TopSection />
       <MiddleSection />
       <BottomSection />

--- a/grass-diary/src/pages/Main/Main.tsx
+++ b/grass-diary/src/pages/Main/Main.tsx
@@ -12,7 +12,7 @@ import subCharacter from '@icon/subCharacter.png';
 import useUser from '@recoil/user/useUser';
 import AnimateReward from './AnimateReward';
 import { checkAuth } from '@utils/authUtils';
-import { Top10Feed, Header, Button } from '@components/index';
+import { Top10Feed, Header, Button, Container } from '@components/index';
 
 const styles = stylex.create({
   title: {
@@ -84,9 +84,10 @@ const styles = stylex.create({
 const TopSectionStyles = stylex.create({
   container: {
     display: 'flex',
+    justifyContent: 'space-evenly',
     alignItems: 'center',
-    justifyContent: 'center',
-    gap: '200px',
+
+    width: '100%',
     backgroundColor: '#F9F9F9',
     height: 400,
     border: 'solid 1px #F9F9F9',
@@ -580,13 +581,13 @@ const Main = () => {
   }, [navigate]);
 
   return (
-    <>
-      <Header margin="auto" />
+    <Container>
+      <Header />
       <TopSection />
       <MiddleSection />
       <BottomSection />
       <Top10Feed />
-    </>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/Main/Main.tsx
+++ b/grass-diary/src/pages/Main/Main.tsx
@@ -15,10 +15,8 @@ import { checkAuth } from '@utils/authUtils';
 import { Top10Feed, Header, Button, Container } from '@components/index';
 
 const styles = stylex.create({
-  title: {
-    fontSize: '80px',
-    color: 'green',
-    fontWeight: 'bold',
+  subContent: {
+    fontSize: '20px',
   },
   imgNav: {
     width: 50,
@@ -109,9 +107,6 @@ const TopSectionStyles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
 
-    fontSize: 30,
-    fontWeight: 'bold',
-
     gap: '20px',
   },
 
@@ -177,11 +172,10 @@ const MiddleSectionStyle = stylex.create({
 
   title: {
     display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: '900px',
-    paddingTop: '50px',
-    paddingBottom: '50px',
+
+    width: '1200px',
+
+    padding: '50px 0 50px 10px',
   },
 
   container: {
@@ -190,11 +184,19 @@ const MiddleSectionStyle = stylex.create({
     gap: '300px',
   },
 
+  contentWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+
   grassContainer: {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
+
+    gap: '15px',
   },
 
   rewardContainer: {
@@ -202,19 +204,15 @@ const MiddleSectionStyle = stylex.create({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-  },
 
-  grassBox: {
-    backgroundColor: '#e0e0e0',
-    width: '20px',
-    height: '20px',
-    margin: '2px',
-    borderRadius: '5px',
+    gap: '15px',
   },
 
   calendar: {
     display: 'flex',
     flexWrap: 'wrap',
+
+    marginBottom: '10px',
   },
 
   day: {
@@ -287,13 +285,15 @@ const TopSection = () => {
           <div {...stylex.props(TopSectionStyles.bannerTitle)}>
             <i
               className="fa-solid fa-lightbulb"
-              style={{ paddingBottom: '20px' }}
+              style={{ fontSize: '30px', paddingBottom: '20px' }}
             ></i>
-            <div>{date ? <p>{date}</p> : <p>Loading...</p>}</div>
+            <h1>{date ? <p>{date}</p> : <p>Loading...</p>}</h1>
           </div>
           <div style={{ display: 'flex', gap: '10px' }}>
             <i className="fa-solid fa-circle-question"></i>
-            <div>{todayQuestion ? <>{todayQuestion}</> : <>Loading...</>}</div>
+            <span>
+              {todayQuestion ? <>{todayQuestion}</> : <>Loading...</>}
+            </span>
           </div>
           <Link to="/creatediary">
             <Button
@@ -330,13 +330,7 @@ const TopSection = () => {
           </div>
           <div {...stylex.props(TopSectionStyles.bottomContent('15px'))}>
             <Link to="/mypage">
-              <div
-                style={{
-                  fontWeight: 'bold',
-                  fontSize: '30px',
-                  cursor: 'pointer',
-                }}
-              >
+              <h1 style={{ cursor: 'pointer' }}>
                 나의 일기장
                 <button {...stylex.props(styles.button)}>
                   <i
@@ -347,9 +341,9 @@ const TopSection = () => {
                     }}
                   ></i>
                 </button>
-              </div>
+              </h1>
             </Link>
-            <div>나의 하루들은 어떻게 흘러갔을까?</div>
+            <span>나의 하루들은 어떻게 흘러갔을까?</span>
           </div>
         </div>
         <div {...stylex.props(TopSectionStyles.bottomBox)}>
@@ -365,13 +359,11 @@ const TopSection = () => {
             ></i>
           </div>
           <div {...stylex.props(TopSectionStyles.bottomContent())}>
-            <div
+            <h1
               onClick={modal}
               style={{
-                fontWeight: 'bold',
-                fontSize: '30px',
-                marginBottom: '10px',
                 cursor: 'pointer',
+                marginBottom: '10px',
               }}
             >
               교환 일기장
@@ -381,9 +373,9 @@ const TopSection = () => {
                   style={{ fontSize: '28px', paddingLeft: '50px' }}
                 ></i>
               </button>
-            </div>
-            <div>친구의 일기를 확인하고</div>
-            <div>나의 이야기를 들려주세요</div>
+            </h1>
+            <span>친구의 일기를 확인하고</span>
+            <span>나의 이야기를 들려주세요</span>
           </div>
         </div>
       </div>
@@ -478,13 +470,12 @@ const MiddleSection = () => {
   return (
     <>
       <div {...stylex.props(MiddleSectionStyle.title)}>
-        <div>
-          <h2>기록 상자</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <h1>기록 상자</h1>
           <span>
             총 {grassCount ? grassCount : 0}개의 기록을 보유하고 있어요!
           </span>
         </div>
-        <div></div>
       </div>
       <div {...stylex.props(MiddleSectionStyle.container)}>
         <div
@@ -511,15 +502,18 @@ const MiddleSection = () => {
             </div>
           </section>
           <h2>나의 이번달 잔디</h2>
-          <span>
-            {currentMonth}월 일기는 현재까지 총 {grassCount ? grassCount : 0}
-            개가 작성되었어요
-          </span>
-          {grassCount ? (
-            <span>리워드를 확인 해보세요!</span>
-          ) : (
-            <span>일기를 쓰고 잔디를 심어보세요!</span>
-          )}
+          <div {...stylex.props(MiddleSectionStyle.contentWrapper)}>
+            <span>
+              {currentMonth}월 일기는 현재까지 총 {grassCount ? grassCount : 0}
+              개가 작성되었어요
+            </span>
+
+            {grassCount ? (
+              <span>리워드를 확인 해보세요!</span>
+            ) : (
+              <span>일기를 쓰고 잔디를 심어보세요!</span>
+            )}
+          </div>
         </div>
         <div
           className="cardSectionR"
@@ -528,13 +522,15 @@ const MiddleSection = () => {
           <img
             src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Party%20Popper.png"
             alt="Party Popper"
-            width="125"
-            height="125"
+            width="170"
+            height="170"
           />
           <AnimateReward n={temporaryPoint} />
           <h2>나의 리워드</h2>
-          <span>잔디를 꾸준히 심고 리워드를 받으세요</span>
-          <span>테마 상점에서 다양한 아이템을 만날 수 있어요</span>
+          <div {...stylex.props(MiddleSectionStyle.contentWrapper)}>
+            <span>잔디를 꾸준히 심고 리워드를 받으세요</span>
+            <span>테마 상점에서 다양한 아이템을 만날 수 있어요</span>
+          </div>
           <Button
             text="테마 상점"
             width="130px"

--- a/grass-diary/src/pages/Main/Main.tsx
+++ b/grass-diary/src/pages/Main/Main.tsx
@@ -84,27 +84,35 @@ const styles = stylex.create({
 const TopSectionStyles = stylex.create({
   container: {
     display: 'flex',
-    justifyContent: 'space-evenly',
+    justifyContent: 'space-around',
     alignItems: 'center',
 
-    width: '100%',
+    width: '1200px',
+    height: '400px',
+
     backgroundColor: '#F9F9F9',
-    height: 400,
-    border: 'solid 1px #F9F9F9',
-    borderRadius: '30px',
+    border: 'solid 1px #BFBFBF',
+    borderRadius: '30px 30px 0 0',
   },
 
   bannerContainer: {
     display: 'flex',
     flexDirection: 'column',
+
+    width: '35%',
     gap: '30px',
+
+    paddingLeft: '20px',
   },
 
   bannerTitle: {
     display: 'flex',
     flexDirection: 'column',
+
+    fontSize: 30,
     fontWeight: 'bold',
-    fontSize: 25,
+
+    gap: '20px',
   },
 
   character: {
@@ -116,37 +124,49 @@ const TopSectionStyles = stylex.create({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: '200px',
-    paddingTop: '50px',
+
+    width: '1200px',
+    height: '300px',
+
+    gap: '30px',
+    paddingTop: '30px',
   },
 
-  bottomLeftBox: {
+  bottomBox: {
     display: 'flex',
-    gap: '100px',
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    width: '100%',
+    height: '100%',
+
     backgroundColor: '#F9F9F9',
-    border: 'solid 1px #F9F9F9',
-    borderRadius: '20px',
-    padding: '70px',
+
+    border: 'solid 1px #BFBFBF',
+    borderRadius: '0 0 20px 20px',
+
+    gap: '40px',
   },
 
-  bottomLeft: {
+  bottomIcon: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    width: '170px',
+    height: '170px',
+
+    borderRadius: '100%',
+    backgroundColor: '#F2F2F2',
+  },
+
+  bottomContent: (gap?: string) => ({
     display: 'flex',
     flexDirection: 'column',
-    gap: '10px',
-  },
-  bottomRightBox: {
-    display: 'flex',
-    gap: '100px',
-    backgroundColor: '#F9F9F9',
-    border: 'solid 1px #F9F9F9',
-    borderRadius: '20px',
-    padding: '70px',
-  },
+    justifyContent: 'center',
 
-  bottomRight: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
+    gap,
+  }),
 });
 
 const MiddleSectionStyle = stylex.create({
@@ -296,19 +316,24 @@ const TopSection = () => {
         </div>
       </div>
       <div {...stylex.props(TopSectionStyles.bottomContainer)}>
-        <div {...stylex.props(TopSectionStyles.bottomLeftBox)}>
-          <div>
-            <button {...stylex.props(styles.button)}>
-              <i className="fa-solid fa-book" style={{ fontSize: '50px' }}></i>
-            </button>
+        <div {...stylex.props(TopSectionStyles.bottomBox)}>
+          <div {...stylex.props(TopSectionStyles.bottomIcon)}>
+            <i
+              className="fa-solid fa-book"
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                fontSize: '80px',
+              }}
+            ></i>
           </div>
-
-          <div {...stylex.props(TopSectionStyles.bottomLeft)}>
+          <div {...stylex.props(TopSectionStyles.bottomContent('15px'))}>
             <Link to="/mypage">
               <div
                 style={{
                   fontWeight: 'bold',
-                  fontSize: '20px',
+                  fontSize: '30px',
                   cursor: 'pointer',
                 }}
               >
@@ -316,7 +341,10 @@ const TopSection = () => {
                 <button {...stylex.props(styles.button)}>
                   <i
                     className="fa-regular fa-circle-right"
-                    style={{ fontSize: '25px', paddingLeft: '90px' }}
+                    style={{
+                      fontSize: '28px',
+                      paddingLeft: '55px',
+                    }}
                   ></i>
                 </button>
               </div>
@@ -324,21 +352,24 @@ const TopSection = () => {
             <div>나의 하루들은 어떻게 흘러갔을까?</div>
           </div>
         </div>
-        <div {...stylex.props(TopSectionStyles.bottomRightBox)}>
-          <div>
-            <button {...stylex.props(styles.button)}>
-              <i
-                className="fa-solid fa-user-group"
-                style={{ fontSize: '50px' }}
-              ></i>
-            </button>
+        <div {...stylex.props(TopSectionStyles.bottomBox)}>
+          <div {...stylex.props(TopSectionStyles.bottomIcon)}>
+            <i
+              className="fa-solid fa-user-group"
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                fontSize: '80px',
+              }}
+            ></i>
           </div>
-          <div {...stylex.props(TopSectionStyles.bottomRight)}>
+          <div {...stylex.props(TopSectionStyles.bottomContent())}>
             <div
               onClick={modal}
               style={{
                 fontWeight: 'bold',
-                fontSize: '20px',
+                fontSize: '30px',
                 marginBottom: '10px',
                 cursor: 'pointer',
               }}
@@ -347,7 +378,7 @@ const TopSection = () => {
               <button {...stylex.props(styles.button)}>
                 <i
                   className="fa-regular fa-circle-right"
-                  style={{ fontSize: '25px', paddingLeft: '90px' }}
+                  style={{ fontSize: '28px', paddingLeft: '50px' }}
                 ></i>
               </button>
             </div>

--- a/grass-diary/src/pages/Main/Main.tsx
+++ b/grass-diary/src/pages/Main/Main.tsx
@@ -172,9 +172,7 @@ const MiddleSectionStyle = stylex.create({
 
   title: {
     display: 'flex',
-
     width: '1200px',
-
     padding: '50px 0 50px 10px',
   },
 
@@ -231,10 +229,19 @@ const MiddleSectionStyle = stylex.create({
 const BottomSectionStyle = stylex.create({
   container: {
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    gap: '800px',
-    paddingTop: '50px',
+
+    width: '1200px',
+
+    padding: '50px 0 0 10px',
+  },
+
+  contentWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    gap: '10px',
   },
 
   title: {
@@ -244,6 +251,7 @@ const BottomSectionStyle = stylex.create({
   },
 
   btn: {
+    fontSize: '20px',
     fontWeight: 'bold',
     border: 'none',
     backgroundColor: 'white',
@@ -471,7 +479,7 @@ const MiddleSection = () => {
     <>
       <div {...stylex.props(MiddleSectionStyle.title)}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <h1>기록 상자</h1>
+          <h1>📫 기록 상자</h1>
           <span>
             총 {grassCount ? grassCount : 0}개의 기록을 보유하고 있어요!
           </span>
@@ -552,7 +560,7 @@ const BottomSection = () => {
   return (
     <>
       <div {...stylex.props(BottomSectionStyle.container)}>
-        <div>
+        <div {...stylex.props(BottomSectionStyle.contentWrapper)}>
           <div {...stylex.props(BottomSectionStyle.title)}>
             <img
               src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Trophy.png"
@@ -560,7 +568,7 @@ const BottomSection = () => {
               width="25"
               height="25"
             />
-            <h2>이번 주 TOP 10</h2>
+            <h1>이번 주 TOP 10</h1>
           </div>
           <span>다른 사람의 하루를 구경하러 가볼까요?</span>
         </div>

--- a/grass-diary/src/pages/MyPage/MyPage.tsx
+++ b/grass-diary/src/pages/MyPage/MyPage.tsx
@@ -4,7 +4,7 @@ import { Container, MainContainer } from './myComponents';
 const MyPage = () => {
   return (
     <Container>
-      <Header />
+      <Header margin="auto" />
       <MainContainer />
     </Container>
   );

--- a/grass-diary/src/pages/MyPage/MyPage.tsx
+++ b/grass-diary/src/pages/MyPage/MyPage.tsx
@@ -1,10 +1,10 @@
-import { Header } from '@components/index';
-import { Container, MainContainer } from './myComponents';
+import { Header, Container } from '@components/index';
+import { MainContainer } from './myComponents';
 
 const MyPage = () => {
   return (
     <Container>
-      <Header margin="auto" />
+      <Header />
       <MainContainer />
     </Container>
   );

--- a/grass-diary/src/pages/MyPage/myComponents.tsx
+++ b/grass-diary/src/pages/MyPage/myComponents.tsx
@@ -10,10 +10,6 @@ import useProfile from '@recoil/profile/useProfile';
 import mainCharacter from '@icon/mainCharacter.png';
 import { Button, EllipsisBox, EllipsisIcon, Profile } from '@components/index';
 
-const Container = ({ children }: IContainer) => {
-  return <div {...stylex.props(styles.container)}>{children}</div>;
-};
-
 const MainContainer = () => {
   const navigate = useNavigate();
 
@@ -186,4 +182,4 @@ const SortButton = ({ onSortChange }: ISortButton) => {
   );
 };
 
-export { Container, MainContainer };
+export { MainContainer };

--- a/grass-diary/src/pages/MyPage/style.ts
+++ b/grass-diary/src/pages/MyPage/style.ts
@@ -1,14 +1,6 @@
 import stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-
-    width: '100vw',
-  },
-
   mainContainer: {
     display: 'flex',
     flexDirection: 'column',

--- a/grass-diary/src/pages/Setting/Setting.tsx
+++ b/grass-diary/src/pages/Setting/Setting.tsx
@@ -52,7 +52,7 @@ const Setting = () => {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <Header />
+      <Header margin="auto" />
       <div {...stylex.props(styles.contentWrap)}>
         <div {...stylex.props(styles.titleSection)}>
           <span {...stylex.props(styles.title)}>설정</span>

--- a/grass-diary/src/pages/Setting/Setting.tsx
+++ b/grass-diary/src/pages/Setting/Setting.tsx
@@ -10,7 +10,7 @@ import {
 import API from '@services/index';
 import useProfile from '@recoil/profile/useProfile';
 import { profileAtom } from '@recoil/profile/profileState';
-import { Header, Profile, Button } from '@components/index';
+import { Container, Header, Profile, Button } from '@components/index';
 
 interface ISettingSection {
   children: React.ReactNode;
@@ -51,8 +51,8 @@ const Setting = () => {
   });
 
   return (
-    <div {...stylex.props(styles.container)}>
-      <Header margin="auto" />
+    <Container>
+      <Header />
       <div {...stylex.props(styles.contentWrap)}>
         <div {...stylex.props(styles.titleSection)}>
           <span {...stylex.props(styles.title)}>설정</span>
@@ -111,7 +111,7 @@ const Setting = () => {
           </div>
         </div>
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/grass-diary/src/pages/Setting/styles.ts
+++ b/grass-diary/src/pages/Setting/styles.ts
@@ -1,17 +1,6 @@
 import stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-
-    width: '100vw',
-    height: '100vh',
-
-    gap: '0.625rem',
-  },
-
   contentWrap: {
     display: 'flex',
     flexDirection: 'column',

--- a/grass-diary/src/pages/Share/Share.tsx
+++ b/grass-diary/src/pages/Share/Share.tsx
@@ -112,7 +112,7 @@ const Share = () => {
 
   return (
     <>
-      <Header />
+      <Header margin="auto" />
       <div {...stylex.props(styles.container)}>
         <section>
           <div {...stylex.props(styles.top10Title)}>🏆 이번 주 TOP 10</div>

--- a/grass-diary/src/pages/Share/Share.tsx
+++ b/grass-diary/src/pages/Share/Share.tsx
@@ -2,7 +2,7 @@ import stylex from '@stylexjs/stylex';
 import { useEffect, useRef, useState } from 'react';
 
 import API from '@services/index';
-import { Feed, Header, Top10Feed } from '@components/index';
+import { Container, Feed, Header, Top10Feed } from '@components/index';
 
 const styles = stylex.create({
   container: {
@@ -111,8 +111,8 @@ const Share = () => {
   }, [latestDatas]);
 
   return (
-    <>
-      <Header margin="auto" />
+    <Container>
+      <Header />
       <div {...stylex.props(styles.container)}>
         <section>
           <div {...stylex.props(styles.top10Title)}>🏆 이번 주 TOP 10</div>
@@ -146,7 +146,7 @@ const Share = () => {
           <div ref={target} {...stylex.props(styles.observer)}></div>
         </div>
       </div>
-    </>
+    </Container>
   );
 };
 

--- a/grass-diary/src/styles/reset.css
+++ b/grass-diary/src/styles/reset.css
@@ -26,10 +26,11 @@ h1,
 h2,
 h3,
 h4,
+p,
 button,
 input,
 label {
-  line-height: 1.1;
+  line-height: 1.34;
 }
 
 h1,
@@ -40,6 +41,15 @@ h4 {
   white-space: pre-wrap;
   word-wrap: break-word; /* IE 5.5-7 */
   white-space: -moz-pre-wrap; /* Firefox 1.0-2.0 */
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+  margin: 0;
+  padding: 0;
 }
 
 a:not([class]) {

--- a/grass-diary/src/types/module.d.ts
+++ b/grass-diary/src/types/module.d.ts
@@ -1,0 +1,1 @@
+declare module '@fullpage/react-fullpage';


### PR DESCRIPTION
## 🔎 작업 내용

- [x] 소개 페이지 `fullpage` 적용

## ⚒️ 구현 중 추가적인 수정 사항

- [x] Header component `margin` 제거 및 `style` 수정
- [x] 메인 페이지 배너, 기록 상자, 이번 주 TOP 10 section `design` 및 `style` 변경
- [x] `reset.css` 속성 추가 및 변경
- [x] Container component 생성 및 적용

```css
// 추가
h1,
h2,
h3,
h4,
p {
  margin: 0;
  padding: 0;
}

// 변경
h1,
h2,
h3,
h4,
p,
button,
input,
label {
  line-height: 1.34;
}
```

## 🖥️ 변경된 화면

### ✨ 소개 페이지 fullpage 적용 화면

![소개페이지_fullpage](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/e0ece5ed-5fbd-4357-bf6e-d991e36cc91a)

### 🌱 기존 메인 페이지
<img width="1470" alt="스크린샷 2024-04-27 오후 10 41 36" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/7ef9ec72-6847-4a9c-9e45-955096f68015">

### ✨ 수정된 메인 페이지
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/9549fad7-1a36-43a1-98d3-d1c96316b85e)
