### PR TITLE
:hammer: fix: 마이 페이지 연간 잔디 오류 수정

### DIFF
--- a/grass-diary/src/pages/MyPage/Grass.tsx
+++ b/grass-diary/src/pages/MyPage/Grass.tsx
@@ -75,6 +75,7 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
       {grass.map((column, index) => (
         <div key={index} {...stylex.props(styles.grass)}>
           {column.map((day, index) => {
+            if (!day) return;
             const writeDay = formatDate(day);
             return (
               <div key={index} {...stylex.props(styles.dayContainer)}>


### PR DESCRIPTION
### 🔎 PR

**이슈 번호**: #111

**변경 유형**: [버그 수정]

### 변경 내용

- **변경 내용**:
  해당 연도의 일 수(365/366)를 초과했을 경우에는 잔디가 생성되지 않도록 아래와 같은 조건문 추가 

```ts
if (!day) return;
```

**체크리스트**:
- [x] 해당 연도의 일 수를 초과했을 경우 잔디 UI가 생성되지 않도록 하는 조건문 추가

### 스크린샷
<img width="1148" alt="스크린샷 2024-05-10 오후 2 32 03" src="https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/756fab4a-7cdc-4def-a669-a05201be4741">
