### PR TITLE
✨ feat: 마이 페이지 연간 잔디 mouseover 시 날짜 표시

### DIFF
--- a/grass-diary/src/pages/MyPage/Grass.tsx
+++ b/grass-diary/src/pages/MyPage/Grass.tsx
@@ -42,7 +42,9 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
   const grassColors = useGrass(memberId);
 
   const handleGrassClick = (date: Date | null) => {
-    setSelectedGrass(formatDate(date));
+    formatDate(date) === selectedGrass
+      ? setSelectedGrass(null)
+      : setSelectedGrass(formatDate(date));
   };
 
   const selectedDate: string | null = selectedGrass

--- a/grass-diary/src/pages/MyPage/Grass.tsx
+++ b/grass-diary/src/pages/MyPage/Grass.tsx
@@ -37,6 +37,7 @@ interface IGrass {
 
 const Grass = ({ setSelectedDiary }: IGrass) => {
   const [selectedGrass, setSelectedGrass] = useState<string | null>(null);
+  const [hoveredGrass, setHoveredGrass] = useState<string | null>(null);
   const { year, grass } = createGrass();
   const { memberId } = useUser();
   const grassColors = useGrass(memberId);
@@ -45,6 +46,12 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
     formatDate(date) === selectedGrass
       ? setSelectedGrass(null)
       : setSelectedGrass(formatDate(date));
+  };
+
+  const handleGrassHover = (date: Date | null) => {
+    date && selectedGrass !== formatDate(date)
+      ? setHoveredGrass(formatDate(date))
+      : setHoveredGrass(null);
   };
 
   const selectedDate: string | null = selectedGrass
@@ -84,6 +91,8 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
                 {grassColors && (
                   <div
                     onClick={() => handleGrassClick(day)}
+                    onMouseOver={() => handleGrassHover(day)}
+                    onMouseOut={() => handleGrassHover(null)}
                     {...stylex.props(
                       styles.grassDate(
                         writeDay === selectedGrass ? '1px solid black' : 'none',
@@ -94,7 +103,12 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
                     )}
                   ></div>
                 )}
-                {formatDate(day) === selectedGrass && (
+                {writeDay === hoveredGrass && writeDay !== selectedGrass && (
+                  <div {...stylex.props(styles.dateBubble)}>
+                    <span>{hoveredGrass}</span>
+                  </div>
+                )}
+                {writeDay === selectedGrass && (
                   <div {...stylex.props(styles.dateBubble)}>
                     <span>{selectedGrass}</span>
                   </div>


### PR DESCRIPTION
## 🔎 PR

**이슈 번호**: #113 

**변경 유형**: [새로운 기능]

## 변경 내용

- **변경 내용 1**:
  기존에는 연간 잔디의 잔디를 클릭하게 되면 다른 잔디로 변경은 가능했지만, 아예 선택을 취소하는 것은 불가능하였기 때문에 토글 기능을 추가해 현재 선택된 잔디를 다시 클릭하면 선택이 해제될 수 있도록 변경함.

- **변경 내용 2**:
  기존에는 사용자가 잔디를 클릭해야만 날짜를 파악 가능했음. 때문에 특정 날짜를 확인하고 싶어도 클릭 전에는 눈에 보이지 않는 UX적인 불편함이 존재해, 사용자가 잔디에 마우스만 올려도 날짜가 표시되도록 `mouseover`를 추가함.

**체크리스트**:
- [x] 현재 선택된 잔디 재클릭 시 선택 해제 (토글 추가)
- [x] 마이 페이지 연간 잔디에 마우스 올릴 경우 해당하는 잔디의 날짜 표시

## 스크린샷 (선택 사항)

#### 1) 현재 선택된 잔디 재클릭 시 선택 해제

#### 2) 마이 페이지 연간 잔디에 마우스 올릴 경우 해당하는 잔디의 날짜 표시
