### PR TITLE
✨ feat: 설정 페이지 닉네임 및 소개글 부분 수정 추가

### DIFF
--- a/grass-diary/src/pages/Setting/Setting.tsx
+++ b/grass-diary/src/pages/Setting/Setting.tsx
@@ -1,5 +1,6 @@
 import styles from './styles';
 import stylex from '@stylexjs/stylex';
+import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import {
   QueryClient,
@@ -30,6 +31,10 @@ const Setting = () => {
   const queryClient: QueryClient = useQueryClient();
   const { nickName, profileIntro }: Partial<IProfile> = useProfile();
   const [profile, setProfile] = useRecoilState(profileAtom);
+
+  useEffect(() => {
+    setProfile({ ...profile, nickName, profileIntro });
+  }, [nickName, profileIntro]);
 
   const handleChangeNickname = (event: React.ChangeEvent<HTMLInputElement>) => {
     setProfile({ ...profile, nickName: event.target.value });
@@ -75,14 +80,16 @@ const Setting = () => {
             <SettingSection label="닉네임">
               <input
                 {...stylex.props(styles.textInput('0 0 0 1.25rem', '3.2rem'))}
-                placeholder={nickName}
+                name="nickName"
+                value={profile.nickName || ''}
                 onChange={handleChangeNickname}
               ></input>
             </SettingSection>
             <SettingSection label="소개글">
               <textarea
                 {...stylex.props(styles.textInput('1rem 1.25rem', '6.25rem'))}
-                placeholder={profileIntro}
+                name="profileIntro"
+                value={profile.profileIntro || ''}
                 onChange={handleChangeProfileIntro}
               ></textarea>
             </SettingSection>

--- a/grass-diary/src/pages/Setting/Setting.tsx
+++ b/grass-diary/src/pages/Setting/Setting.tsx
@@ -101,7 +101,7 @@ const Setting = () => {
                   border="1px solid #929292"
                   onClick={() =>
                     updateProfile.mutate({
-                      nickName: profile.nickName,
+                      nickname: profile.nickName,
                       profileIntro: profile.profileIntro,
                     })
                   }

--- a/grass-diary/src/types/profile.ts
+++ b/grass-diary/src/types/profile.ts
@@ -6,7 +6,7 @@ interface IProfile {
 
 // Setting Page updateProfile Type
 interface IUpdateProfile {
-  nickName?: string;
+  nickname?: string;
   profileIntro?: string;
 }
 


### PR DESCRIPTION
### 🔎 PR

**이슈 번호**: #115 

**변경 유형**: [새로운 기능, 버그 수정]

## 변경 내용

- **변경 내용 1**:
  필드 이름 변경으로 인해 기존 설정 페이지에서 닉네임 수정이 되지 않던 버그 수정

- **변경 내용 2**:
  기존에는 설정 페이지에서 닉네임과 소개글을 변경할 경우, 닉네임과 소개글이 placeholder로 지정되어 있어 사용자가 일부만 수정하고 싶은 경우에도 전체를 수정해야 하는 불편함이 존재했음. 따라서 부분 수정이 가능하도록 기존 정보를 입력 필드에 바인딩함.

**체크리스트**:
- [x] 기존 닉네임 수정 안 되던 버그 수정
- [x] 사용자 기본 정보 입력 필드에 바인딩

## 스크린샷 

![change-userinfo](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/ca1d62dd-f818-415d-ae71-cc26c4ca6af4)