### PR TITLE
🐛bug: PopularFeed 피드 없을 때 문구 뜨지 않는 버그 수정

### DIFF
--- a/grass-diary/src/components/Feed/PopularFeed.tsx
+++ b/grass-diary/src/components/Feed/PopularFeed.tsx
@@ -15,9 +15,9 @@ const styles = stylex.create({
     },
   },
   noFeed: {
-    height: '440px',
+    height: '400px',
     textAlign: 'center',
-    lineHeight: '440px',
+    lineHeight: '400px',
   },
 });
 
@@ -53,7 +53,7 @@ const PopularFeed = () => {
       ) : (
         feedList
       )}
-      {!top10 ? (
+      {top10 && !top10.length ? (
         <div {...stylex.props(styles.noFeed)}>
           이번 주는 공개된 일기가 아직 없어요
         </div>


### PR DESCRIPTION
### 🔎 PR

**이슈 번호**: #117 

**변경 유형**: [버그 수정]

### 변경 내용

- **변경 내용 1**:
PopularFeed( Top10 일기 )에 일기피드가 하나도 없을 때의 UI가 나오지 않아 수정. 
`이번 주는 공개된 일기가 아직 없어요` 문구가 뜨고 해당 구역의 height, lineheight 400px로 줄임. 

**체크리스트**:
- [x] 피드가 하나도 없을 경우의 UI 조건 다시 설정하기 

### 버그 수정 완료 스크린샷 
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/c4f4cac4-fb30-4ffb-b2fa-ada1e1dfe1a4)
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/71370666-c21d-4657-9591-4cbf4c2db465)

