### PR TITLE
✨ feat: 상세페이지 이미지 불러오기 기능 구현

### DIFF
--- a/grass-diary/src/pages/Diary/Diary.tsx
+++ b/grass-diary/src/pages/Diary/Diary.tsx
@@ -121,6 +121,10 @@ const contentStyle = stylex.create({
   content: {
     minHeight: '200px',
   },
+  image: {
+    width: '500px',
+    padding: '30px 0',
+  },
 });
 
 const Diary = () => {
@@ -203,6 +207,12 @@ const Diary = () => {
               return `#${tag.tag} `;
             })}
           </div>
+          {detail?.hasImage ? (
+            <img
+              {...stylex.props(contentStyle.image)}
+              src={detail?.imageURL}
+            ></img>
+          ) : null}
           <div
             {...stylex.props(contentStyle.content)}
             dangerouslySetInnerHTML={createMarkup(detail?.content)}

--- a/grass-diary/src/pages/Diary/Diary.tsx
+++ b/grass-diary/src/pages/Diary/Diary.tsx
@@ -9,6 +9,7 @@ import EMOJI from '@constants/emoji';
 import Setting from './Setting';
 import { useDiaryDetail } from '@hooks/useDiaryDetail';
 import axios from 'axios';
+import ImageModal from './modal/ImageModal';
 
 const styles = stylex.create({
   wrap: {
@@ -122,8 +123,10 @@ const contentStyle = stylex.create({
     minHeight: '200px',
   },
   image: {
-    width: '500px',
-    padding: '30px 0',
+    display: 'block',
+    margin: '30px auto',
+    width: '50%',
+    cursor: 'pointer',
   },
 });
 
@@ -133,9 +136,16 @@ const Diary = () => {
   const { memberId } = useUser();
   const [likeCount, setLikeCount] = useState(0);
   const [mood, setMood] = useState('');
+  const [imageModal, setImageModal] = useState(false);
   const { detail, writer, isLoading, isError, error } = useDiaryDetail(
     diaryId!,
   );
+
+  const zoom = () => {
+    if (!imageModal) {
+      setImageModal(true);
+    }
+  };
 
   useEffect(() => {
     if (axios.isAxiosError<ResponseType, any>(error)) {
@@ -171,6 +181,9 @@ const Diary = () => {
 
   return (
     <Container>
+      {imageModal && detail?.hasImage && (
+        <ImageModal img={detail?.imageURL} setImageModal={setImageModal} />
+      )}
       <Header />
       <div {...stylex.props(styles.wrap)}>
         <BackButton />
@@ -207,12 +220,13 @@ const Diary = () => {
               return `#${tag.tag} `;
             })}
           </div>
-          {detail?.hasImage ? (
+          {detail?.hasImage && (
             <img
               {...stylex.props(contentStyle.image)}
               src={detail?.imageURL}
+              onClick={zoom}
             ></img>
-          ) : null}
+          )}
           <div
             {...stylex.props(contentStyle.content)}
             dangerouslySetInnerHTML={createMarkup(detail?.content)}

--- a/grass-diary/src/pages/Diary/modal/ImageModal.tsx
+++ b/grass-diary/src/pages/Diary/modal/ImageModal.tsx
@@ -1,0 +1,79 @@
+import stylex from '@stylexjs/stylex';
+import { useEffect } from 'react';
+
+const imageModal = stylex.create({
+  background: {
+    zIndex: '998',
+    position: 'fixed',
+    width: '100vw',
+    height: '100vh',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  imageWrap: {
+    position: 'relative',
+    width: '80vw',
+    height: '90vh',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignContent: 'center',
+  },
+  imageBox: {
+    zIndex: '999',
+    objectFit: 'contain',
+  },
+  closeBtn: {
+    position: 'relative',
+    width: '36px',
+    height: '36px',
+    padding: '0',
+    margin: '0 10px',
+    border: '1px solid #fff',
+    borderRadius: '18px',
+    cursor: 'pointer',
+    transition: '0.3s',
+    background: { default: 'none', ':hover': '#fff' },
+    color: { default: '#fff', ':hover': '#000' },
+  },
+  closeIcon: {
+    position: 'absolute',
+    top: '0',
+    width: '34px',
+    lineHeight: '36px',
+  },
+});
+
+type Props = {
+  img: string;
+  setImageModal: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const ImageModal = ({ img, setImageModal }: Props) => {
+  const onClick = () => {
+    setImageModal(false);
+  };
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, []);
+
+  return (
+    <div {...stylex.props(imageModal.background)}>
+      <div {...stylex.props(imageModal.imageWrap)}>
+        <img src={img} {...stylex.props(imageModal.imageBox)}></img>
+        <button {...stylex.props(imageModal.closeBtn)} onClick={onClick}>
+          <div {...stylex.props(imageModal.closeIcon)}>
+            <i className="fa-solid fa-x"></i>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ImageModal;

--- a/grass-diary/src/types/diary.ts
+++ b/grass-diary/src/types/diary.ts
@@ -85,4 +85,5 @@ interface IDiaryDetail extends IDiary {
   hasTag: null;
   id: number;
   memberId: number;
+  imageURL: string;
 }


### PR DESCRIPTION
### 🔎 PR

**이슈 번호**: #126 

**변경 유형**: [새로운 기능]

## 변경 내용
 **변경 내용**:
  이미지 파일을 업로드 했을 시 해당 일기 상세 페이지에서 이미지가 불러와지도록 구현

**체크리스트**:
- [x] 상세페이지 이미지 기능 구현
- [x] 이미지 클릭 시, 이미지 확대하여 보여주는 기능 

## 참고 사항 
- 이미지 파일 업로드는 `postman` 를 활용하여 데이터를 직접 POST 한 후 사용. 
- [백엔드 레포 PR 참고](https://github.com/CHZZK-Study/Grass-Diary-Server/pull/74) 

## 스크린샷 
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/33d34c3f-7dd4-477c-a87e-008ae2b77c08)
- 이미지 클릭 시 
![image](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/97906653/fdc677f7-8ab8-484f-b7cc-f3d6b1511403)


