### PR TITLE
🔨fix: 로그아웃 시 헤더 메뉴바 사라지지 않는 오류 수정

### DIFF
--- a/grass-diary/src/components/Header.tsx
+++ b/grass-diary/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Profile } from '@components/index';
 import useLogout from '@hooks/useLogout';
 import useUser from '@recoil/user/useUser';
+import { useQueryClient } from '@tanstack/react-query';
 
 const header = stylex.create({
   container: (position?: string) => ({
@@ -93,9 +94,10 @@ interface IMenuBar {
 
 const MenuBar = ({ toggle, headerRef }: IMenuBar) => {
   const clearAuth = useLogout();
-
+  const queryClient = useQueryClient();
   const handleLogout = () => {
     clearAuth();
+    queryClient.resetQueries({ queryKey: ['memberId'] });
   };
 
   return (


### PR DESCRIPTION
### 🔎 PR

**이슈 번호**: #127 

**변경 유형**: [ 버그 수정]

### 변경 내용

로그인 유저만 확인할 수 있는 헤더의 메뉴바 및 프로필 사진이 로그아웃 시켜도 계속 남아있던 버그를 수정함.
로그아웃을 시켜도 쿼리가 전에 요청하여 받아두었던 memberId 데이터를 참조하기 때문에 문제가 발생하였음.
로그아웃 시 memberId 쿼리의 상태를 초기화하여 데이터를 초기 상태로 돌리기 위해 로그아웃 버튼 함수에 `resetQueries` 사용.
```tsx
// Header.tsx 

const queryClient = useQueryClient();

const handleLogout = () => {
    clearAuth();
    queryClient.resetQueries({ queryKey: ['memberId'] });
};
```


