### PR TITLE
✨ feat: 마이 페이지 일기 해시태그 목록 구현

### DIFF
--- a/grass-diary/src/hooks/useDiary.ts
+++ b/grass-diary/src/hooks/useDiary.ts
@@ -28,8 +28,6 @@ const useDiary = ({ memberId, currentPage, sortOrder }: IUseDiaryProps) => {
     queryKey,
     queryFn,
     enabled: !!memberId,
-    onError: error =>
-      console.error(`사용자의 일기를 조회할 수 없습니다. ${error}`),
   });
 
   const diaryList: IDiary[] = diary?.content || [];

--- a/grass-diary/src/pages/MyPage/Diary.tsx
+++ b/grass-diary/src/pages/MyPage/Diary.tsx
@@ -91,6 +91,14 @@ const Diary = ({ searchTerm, sortOrder, selectedDiary }: IDiaryProps) => {
 
   return (
     <>
+      <aside {...stylex.props(styles.hashtagListContainer)}>
+        <div {...stylex.props(styles.hashtagListTitle)}>해시태그 목록</div>
+        <ul {...stylex.props(styles.hashtagList)}>
+          <li>
+            <a href="/mypage">전체 보기 ({`3`})</a>
+          </li>
+        </ul>
+      </aside>
       <div {...stylex.props(styles.diaryList)}>
         {filteredDiaryList.map((diary, index) => (
           <DiaryItem

--- a/grass-diary/src/pages/MyPage/Grass.tsx
+++ b/grass-diary/src/pages/MyPage/Grass.tsx
@@ -32,7 +32,7 @@ const createGrass: TCreateGrass = () => {
 };
 
 interface IGrass {
-  setSelectedDiary: React.Dispatch<React.SetStateAction<IDiary | undefined>>;
+  setSelectedDiary: React.Dispatch<React.SetStateAction<IDiary[] | undefined>>;
 }
 
 const Grass = ({ setSelectedDiary }: IGrass) => {
@@ -73,7 +73,7 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
   });
 
   useEffect(() => {
-    if (selectedDiary) setSelectedDiary(selectedDiary);
+    if (selectedDiary) setSelectedDiary([selectedDiary]);
     if (!selectedDiary) setSelectedDiary(undefined);
   }, [selectedDiary]);
 

--- a/grass-diary/src/pages/MyPage/Grass.tsx
+++ b/grass-diary/src/pages/MyPage/Grass.tsx
@@ -70,8 +70,6 @@ const Grass = ({ setSelectedDiary }: IGrass) => {
         ({ data }) => data,
       ),
     enabled: !!selectedGrass && !!memberId,
-    onError: error =>
-      console.error(`선택된 날짜의 일기를 불러올 수 없습니다. ${error}`),
   });
 
   useEffect(() => {

--- a/grass-diary/src/pages/MyPage/myComponents.tsx
+++ b/grass-diary/src/pages/MyPage/myComponents.tsx
@@ -16,7 +16,7 @@ const MainContainer = () => {
   const [toggleButton, setToggleButton] = useState<string>('나의 일기장');
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [sortOrder, setSortOrder] = useState<string>('latest');
-  const [selectedDiary, setSelectedDiary] = useState<IDiary | undefined>(
+  const [selectedDiary, setSelectedDiary] = useState<IDiary[] | undefined>(
     undefined,
   );
 
@@ -54,6 +54,7 @@ const MainContainer = () => {
         <SortButton onSortChange={handleSortChange} />
         {toggleButton === '나의 일기장' ? (
           <Diary
+            setSelectedDiary={setSelectedDiary}
             searchTerm={searchTerm}
             sortOrder={sortOrder}
             selectedDiary={selectedDiary}
@@ -92,7 +93,7 @@ const ToggleButton = ({ buttonLabel, handleToggleButton }: IToggleButton) => {
 };
 
 interface IProfileSection {
-  setSelectedDiary: React.Dispatch<React.SetStateAction<IDiary | undefined>>;
+  setSelectedDiary: React.Dispatch<React.SetStateAction<IDiary[] | undefined>>;
 }
 
 const ProfileSection = ({ setSelectedDiary }: IProfileSection) => {

--- a/grass-diary/src/pages/MyPage/style.ts
+++ b/grass-diary/src/pages/MyPage/style.ts
@@ -149,6 +149,8 @@ const styles = stylex.create({
     flexDirection: 'column',
     alignItems: 'center',
 
+    position: 'relative',
+
     width: '70%',
     gap: '20px',
   },
@@ -181,6 +183,35 @@ const styles = stylex.create({
     justifyContent: 'flex-end',
 
     width: '95%',
+  },
+
+  hashtagListContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    position: 'absolute',
+
+    top: '8rem',
+    left: '-13.5rem',
+
+    width: '11.5rem',
+    height: '12.5rem',
+
+    textIndent: '0.2rem',
+  },
+
+  hashtagListTitle: {
+    marginBottom: '0.2rem',
+    paddingBottom: '0.5rem',
+    borderBottom: '1px solid #BFBFBF',
+
+    fontSize: '1rem',
+    fontWeight: '600',
+  },
+
+  hashtagList: {
+    padding: '0',
+    listStyle: 'none',
   },
 
   diaryList: {

--- a/grass-diary/src/pages/MyPage/style.ts
+++ b/grass-diary/src/pages/MyPage/style.ts
@@ -212,6 +212,7 @@ const styles = stylex.create({
   hashtagList: {
     padding: '0',
     listStyle: 'none',
+    lineHeight: '1.7',
   },
 
   diaryList: {
@@ -263,7 +264,12 @@ const styles = stylex.create({
   },
 
   hashtag: {
-    color: '#777777',
+    cursor: 'pointer',
+  },
+
+  selectedHashtag: {
+    textDecoration: 'none',
+    color: '#43e312',
   },
 
   diaryContent: {

--- a/grass-diary/src/styles/reset.css
+++ b/grass-diary/src/styles/reset.css
@@ -79,10 +79,6 @@ textarea:not([rows]) {
   scroll-margin-block: 5ex;
 }
 
-li:hover {
-  background-color: #e2e2e2;
-}
-
 p {
   white-space: pre-wrap;
   word-wrap: break-word; /* IE 5.5-7 */


### PR DESCRIPTION
## 🔎 PR

**이슈 번호**: #125 

**변경 유형**: [새로운 기능]

## 변경 내용

- **변경 내용**: 
  마이 페이지의 일기 목록 좌측에 사용자가 작성한 해시태그 목록을 표시하고, 해시태그를 클릭할 시 해당하는 해시태그가 포함된 일기만 필터링되어 나타나도록 구현

**체크리스트**:
- [x] 해시태그 목록 UI 구현
- [x] 해시태그 클릭 시 해당하는 해시태그가 포함된 일기 필터링되어 나타나도록 구현

## 스크린샷 (선택 사항)
![hashtag-list](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/3122bc3e-611a-4a71-aed6-8327b5539920)

## 추후 개선해야 할 사항 🧐
- 현재 해시태그를 클릭했을 시 일기가 필터링되는 과정에서 데이터 로드 시간으로 인해 모든 일기가 우선적으로 나타난 뒤 일기가 필터링되는 현상이 발생하고 있습니다. (하단 이미지 참고) 해당 버그는 다른 작업부터 빠르게 마무리한 뒤 수정 진행하겠습니다!

![hashtag-list-bug](https://github.com/CHZZK-Study/Grass-Diary-Client/assets/106158901/756ab8a5-8a76-4b5d-934f-c19a0903495e)

- 사용자가 특정 해시태그를 작성한 게시글의 개수 표시