### PR TITLE
♻ refactor: EditDiary 페이지 Tanstack query 적용 및 localStroage의 lastWritingDate 사라짐 현상 해결

### DIFF
--- a/grass-diary/src/components/Feed/PopularFeed.tsx
+++ b/grass-diary/src/components/Feed/PopularFeed.tsx
@@ -22,11 +22,6 @@ const styles = stylex.create({
   },
 });
 
-interface INormalLikeProps {
-  likeCount: number;
-  justifyContent: string;
-}
-
 const PopularFeed = () => {
   const { data: top10 } = usePopularDiaries();
 
@@ -46,7 +41,7 @@ const PopularFeed = () => {
       likeCount={data.diaryLikeCount}
       link={`/diary/${data.diaryId}`}
       createdAt={data.createdAt}
-      content={data.diaryContent}
+      content={data.content}
       name={data.nickname}
       memberId={data.memberId}
     />

--- a/grass-diary/src/hooks/api/useDiaryDetail.ts
+++ b/grass-diary/src/hooks/api/useDiaryDetail.ts
@@ -3,9 +3,12 @@ import { useWriterProfile } from './useWriterProfile';
 import API from '@services/index';
 import { END_POINT } from '@constants/api';
 import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
-const fetchDiaryDetails = (id: Id) => {
-  return API.get(END_POINT.DIARY(id));
+const fetchDiaryDetails = async (id: Id): Promise<IDiaryDetail> => {
+  const res = await API.get(END_POINT.DIARY(id));
+
+  return res.data;
 };
 
 export const useDiaryDetail = (diaryId: Id) => {
@@ -16,15 +19,18 @@ export const useDiaryDetail = (diaryId: Id) => {
     error,
   } = useQuery<IDiaryDetail, AxiosError, IDiaryDetail, [string, Id]>({
     queryKey: ['get-diaryDetail', diaryId],
-    queryFn: async () => {
-      const res = await fetchDiaryDetails(diaryId);
-      return res.data;
-    },
+    queryFn: () => fetchDiaryDetails(diaryId),
     retry: 1,
   });
 
   const writerId = detail?.memberId;
   const { data: writer } = useWriterProfile(writerId!);
+  const navigate = useNavigate();
 
-  return { detail, writer, isLoading, isError, error };
+  if (isError) {
+    console.error(error.message);
+    navigate('/non-existent-page');
+  }
+
+  return { detail, writer, isLoading };
 };

--- a/grass-diary/src/hooks/api/usePatchDiary.ts
+++ b/grass-diary/src/hooks/api/usePatchDiary.ts
@@ -14,7 +14,7 @@ interface PatchAxiosProps {
   formData: FormData;
 }
 
-const patchAxios = ({ diaryId, formData }: PatchAxiosProps) => {
+const fetchAxios = ({ diaryId, formData }: PatchAxiosProps) => {
   return API.patch(END_POINT.DIARY(diaryId), formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
@@ -40,12 +40,12 @@ export const usePatchDiary = ({
   if (file) formData.append('image', file);
 
   return useMutation({
-    mutationFn: () => patchAxios({ diaryId, formData }),
+    mutationFn: () => fetchAxios({ diaryId, formData }),
     onSuccess() {
       navigate(`/diary/${diaryId}`, { replace: true, state: 'editcomplete' });
     },
     onError(error) {
-      console.error(error);
+      console.error(error.message);
     },
   });
 };

--- a/grass-diary/src/hooks/api/usePatchDiary.ts
+++ b/grass-diary/src/hooks/api/usePatchDiary.ts
@@ -3,7 +3,18 @@ import { END_POINT } from '@constants/api';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-const patchAxios = (diaryId, formData) => {
+interface PatchDiaryProps {
+  diaryId: Id;
+  file: File | null;
+  requestDto: RequestDto;
+}
+
+interface PatchAxiosProps {
+  diaryId: Id;
+  formData: FormData;
+}
+
+const patchAxios = ({ diaryId, formData }: PatchAxiosProps) => {
   return API.patch(END_POINT.DIARY(diaryId), formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
@@ -11,7 +22,11 @@ const patchAxios = (diaryId, formData) => {
   });
 };
 
-export const usePatchDiary = (diaryId, file, requestDto) => {
+export const usePatchDiary = ({
+  diaryId,
+  file,
+  requestDto,
+}: PatchDiaryProps) => {
   const formData = new FormData();
   const navigate = useNavigate();
 
@@ -25,7 +40,7 @@ export const usePatchDiary = (diaryId, file, requestDto) => {
   if (file) formData.append('image', file);
 
   return useMutation({
-    mutationFn: () => patchAxios(diaryId, formData),
+    mutationFn: () => patchAxios({ diaryId, formData }),
     onSuccess() {
       navigate(`/diary/${diaryId}`, { replace: true, state: 'editcomplete' });
     },

--- a/grass-diary/src/hooks/api/usePatchDiary.ts
+++ b/grass-diary/src/hooks/api/usePatchDiary.ts
@@ -1,0 +1,36 @@
+import API from '@services/index';
+import { END_POINT } from '@constants/api';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+const patchAxios = (diaryId, formData) => {
+  return API.patch(END_POINT.DIARY(diaryId), formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+};
+
+export const usePatchDiary = (diaryId, file, requestDto) => {
+  const formData = new FormData();
+  const navigate = useNavigate();
+
+  formData.append(
+    'requestDto',
+    new Blob([JSON.stringify(requestDto)], {
+      type: 'application/json',
+    }),
+  );
+
+  if (file) formData.append('image', file);
+
+  return useMutation({
+    mutationFn: () => patchAxios(diaryId, formData),
+    onSuccess() {
+      navigate(`/diary/${diaryId}`, { replace: true, state: 'editcomplete' });
+    },
+    onError(error) {
+      console.error(error);
+    },
+  });
+};

--- a/grass-diary/src/hooks/api/useTodayDate.ts
+++ b/grass-diary/src/hooks/api/useTodayDate.ts
@@ -1,17 +1,26 @@
 import { END_POINT } from '@constants/api';
+import { CONSOLE_ERROR } from '@constants/message';
 import API from '@services/index';
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
-const fetchAxios = () => {
-  return API.get(END_POINT.TODAY_DATE);
+const fetchAxios = async (): Promise<TodayInfo> => {
+  const res = await API.get(END_POINT.TODAY_DATE);
+
+  return res.data;
 };
 
 export const useTodayDate = () => {
-  return useQuery<TodayInfo>({
+  const {
+    data: date,
+    isError,
+    error,
+  } = useQuery<TodayInfo, AxiosError, TodayInfo, [string]>({
     queryKey: ['todayDate'],
-    queryFn: async () => {
-      const res = await fetchAxios();
-      return res.data;
-    },
+    queryFn: fetchAxios,
   });
+
+  if (isError) console.error(CONSOLE_ERROR.DATE.GET + error.message);
+
+  return { date };
 };

--- a/grass-diary/src/hooks/api/useTodayDate.ts
+++ b/grass-diary/src/hooks/api/useTodayDate.ts
@@ -1,0 +1,17 @@
+import { END_POINT } from '@constants/api';
+import API from '@services/index';
+import { useQuery } from '@tanstack/react-query';
+
+const fetchAxios = () => {
+  return API.get(END_POINT.TODAY_DATE);
+};
+
+export const useTodayDate = () => {
+  return useQuery<TodayInfo>({
+    queryKey: ['todayDate'],
+    queryFn: async () => {
+      const res = await fetchAxios();
+      return res.data;
+    },
+  });
+};

--- a/grass-diary/src/hooks/api/useTodayDate.ts
+++ b/grass-diary/src/hooks/api/useTodayDate.ts
@@ -4,7 +4,7 @@ import API from '@services/index';
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-const fetchAxios = async (): Promise<TodayInfo> => {
+const fetchAxios = async (): Promise<TodayDate> => {
   const res = await API.get(END_POINT.TODAY_DATE);
 
   return res.data;
@@ -15,7 +15,7 @@ export const useTodayDate = () => {
     data: date,
     isError,
     error,
-  } = useQuery<TodayInfo, AxiosError, TodayInfo, [string]>({
+  } = useQuery<TodayDate, AxiosError, TodayDate, [string]>({
     queryKey: ['todayDate'],
     queryFn: fetchAxios,
   });

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -10,8 +10,8 @@ import useUser from '@recoil/user/useUser';
 import { Header, BackButton, Button, Container } from '@components/index';
 import EMOJI from '@constants/emoji';
 import 'dayjs/locale/ko';
-import { CONSOLE_ERROR, ERROR } from '@constants/message';
-import { useParamsId } from '@hooks/useParamsId';
+import { ERROR } from '@constants/message';
+import { useTodayDate } from '@hooks/api/useTodayDate';
 
 const CreateDiaryStyle = stylex.create({
   container: {
@@ -100,6 +100,7 @@ const CreateDiaryStyle = stylex.create({
 const CreateDiary = () => {
   const navigate = useNavigate();
   const { memberId } = useUser();
+  const { date } = useTodayDate();
   const [diaryInfo, setDiaryInfo] = useState<IDiaryInfo>({
     hashArr: [],
     moodValue: 5,
@@ -173,21 +174,6 @@ const CreateDiary = () => {
     setDiaryField({ hashArr: diaryInfo.hashArr.filter((_, i) => i !== index) });
   };
 
-  useEffect(() => {
-    API.get<IDiaryInfo>(END_POINT.TODAY_DATE)
-      .then(response => {
-        setDiaryField({
-          year: response.data.year,
-          month: response.data.month,
-          date: response.data.date,
-          day: response.data.day,
-        });
-      })
-      .catch(error => {
-        console.error(CONSOLE_ERROR.DATE.GET + error);
-      });
-  }, []);
-
   const checkWritingPermission = () => {
     const lastWritingDate = localStorage.getItem('lastWritingDate');
     const currentDate = `${diaryInfo.year}년/${diaryInfo.month}월/${diaryInfo.date}일`;
@@ -215,11 +201,6 @@ const CreateDiary = () => {
       }),
     );
 
-    const config = {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    };
     if (!checkWritingPermission()) {
       Swal.fire({
         title: ERROR.DIARY_ALREADY_EXISTS,
@@ -253,6 +234,17 @@ const CreateDiary = () => {
       console.error(error);
     }
   };
+
+  useEffect(() => {
+    if (date) {
+      setDiaryField({
+        year: date.year,
+        month: date.month,
+        date: date.date,
+        day: date.day,
+      });
+    }
+  }, [date]);
 
   return (
     <Container>

--- a/grass-diary/src/pages/DiaryDetail/DiaryDetail.tsx
+++ b/grass-diary/src/pages/DiaryDetail/DiaryDetail.tsx
@@ -1,6 +1,5 @@
 import stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 
 import { Header, BackButton, Like, Container } from '@components/index';
@@ -8,7 +7,6 @@ import useUser from '@recoil/user/useUser';
 import EMOJI from '@constants/emoji';
 import Setting from './Setting';
 import { useDiaryDetail } from '@hooks/api/useDiaryDetail';
-import axios from 'axios';
 import ImageModal from './modal/ImageModal';
 import { useParamsId } from '@hooks/useParamsId';
 
@@ -131,31 +129,19 @@ const contentStyle = stylex.create({
   },
 });
 
-interface ResponseDataType {
-  message: string;
-}
-
 const DiaryDetail = () => {
-  const navigate = useNavigate();
   const diaryId = useParamsId();
   const { memberId } = useUser();
   const [likeCount, setLikeCount] = useState(0);
   const [mood, setMood] = useState('');
   const [imageModal, setImageModal] = useState(false);
-  const { detail, writer, isLoading, isError, error } = useDiaryDetail(diaryId);
+  const { detail, writer, isLoading } = useDiaryDetail(diaryId);
 
   const zoom = () => {
     if (!imageModal) {
       setImageModal(true);
     }
   };
-
-  useEffect(() => {
-    if (axios.isAxiosError<ResponseDataType, any>(error)) {
-      console.log('error: ', error?.response?.data.message);
-      navigate('/non-existent-page');
-    }
-  }, [isError, isLoading]);
 
   useEffect(() => {
     if (detail) {

--- a/grass-diary/src/pages/DiaryDetail/Setting.tsx
+++ b/grass-diary/src/pages/DiaryDetail/Setting.tsx
@@ -4,7 +4,6 @@ import { EllipsisIcon, EllipsisBox } from '@components/index';
 import UnmodifyModal from './modal/UnmodifyModal';
 import ConfirmDeleteModal from './modal/ConfirmDeleteModal';
 import { useTodayDate } from '@hooks/api/useTodayDate';
-import { create } from 'node_modules/axios/index.d.cts';
 
 type SettingProps = {
   diaryId: Id;
@@ -13,7 +12,7 @@ type SettingProps = {
 
 const Setting = ({ diaryId, createdDate }: SettingProps) => {
   const navigate = useNavigate();
-  const { data: date } = useTodayDate();
+  const { date } = useTodayDate();
   const [canEdit, setCanEdit] = useState(false);
   const [editModal, setEditModal] = useState(false);
   const [confirmModal, setConfirmModal] = useState(false);
@@ -21,7 +20,6 @@ const Setting = ({ diaryId, createdDate }: SettingProps) => {
   const showConfirmModal = () => setConfirmModal(true);
 
   const linkToModify = () => {
-    localStorage.removeItem('lastWritingDate');
     if (!canEdit && !editModal) {
       setEditModal(true);
       return;

--- a/grass-diary/src/pages/DiaryDetail/Setting.tsx
+++ b/grass-diary/src/pages/DiaryDetail/Setting.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { EllipsisIcon, EllipsisBox } from '@components/index';
 import UnmodifyModal from './modal/UnmodifyModal';
 import ConfirmDeleteModal from './modal/ConfirmDeleteModal';
+import { useTodayDate } from '@hooks/api/useTodayDate';
+import { create } from 'node_modules/axios/index.d.cts';
 
 type SettingProps = {
   diaryId: Id;
@@ -11,7 +13,7 @@ type SettingProps = {
 
 const Setting = ({ diaryId, createdDate }: SettingProps) => {
   const navigate = useNavigate();
-  const date = new Date();
+  const { data: date } = useTodayDate();
   const [canEdit, setCanEdit] = useState(false);
   const [editModal, setEditModal] = useState(false);
   const [confirmModal, setConfirmModal] = useState(false);
@@ -28,12 +30,12 @@ const Setting = ({ diaryId, createdDate }: SettingProps) => {
   };
 
   useEffect(() => {
-    if (createdDate) {
+    if (createdDate && date) {
       if (
         // 당일 : 일기 수정 가능
-        createdDate.slice(0, 2) === String(date.getFullYear()).slice(2, 4) &&
-        +createdDate.slice(5, 6) === date.getMonth() + 1 &&
-        +createdDate.slice(8, 10) === date.getDate()
+        +createdDate.slice(0, 2) === date.year % 100 &&
+        +createdDate.slice(5, 6) === date.month &&
+        +createdDate.slice(8, 10) === date.date
       ) {
         setCanEdit(true);
       } else {

--- a/grass-diary/src/pages/EditDiary/EditDiary.tsx
+++ b/grass-diary/src/pages/EditDiary/EditDiary.tsx
@@ -117,8 +117,14 @@ const EditDiary = () => {
   const [file, setFile] = useState(null);
   const [imageURL, setImageURL] = useState('');
   const [hasImage, setHasImage] = useState(false);
-  const [requestDto, setRequestDto] = useState({});
-  const { mutate } = usePatchDiary(diaryId, file, requestDto);
+  const [requestDto, setRequestDto] = useState<RequestDto>({
+    content: '',
+    isPrivate: true,
+    conditionLevel: `LEVEL_1`,
+    hashtags: [],
+    hasImage: false,
+  });
+  const { mutate } = usePatchDiary({ diaryId, file, requestDto });
 
   // 상태 업데이트 함수
   const setDiaryField = (field: Partial<IDiaryInfo>) => {

--- a/grass-diary/src/pages/EditDiary/EditDiary.tsx
+++ b/grass-diary/src/pages/EditDiary/EditDiary.tsx
@@ -1,17 +1,16 @@
 import stylex from '@stylexjs/stylex';
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Swal from 'sweetalert2';
 import QuillEditor from '../CreateDiary/QuillEditor';
 
-import API from '@services/index';
-import { END_POINT } from '@constants/api';
 import { Header, BackButton, Button, Container } from '@components/index';
 import EMOJI from '@constants/emoji';
 import 'dayjs/locale/ko';
-import { CONSOLE_ERROR, ERROR } from '@constants/message';
+import { ERROR } from '@constants/message';
 import { useParamsId } from '@hooks/useParamsId';
 import { usePatchDiary } from '@hooks/api/usePatchDiary';
+import { useTodayDate } from '@hooks/api/useTodayDate';
+import { useDiaryDetail } from '@hooks/api/useDiaryDetail';
 
 const CreateDiaryStyle = stylex.create({
   container: {
@@ -98,8 +97,6 @@ const CreateDiaryStyle = stylex.create({
 });
 
 const EditDiary = () => {
-  const diaryId = useParamsId();
-
   const [diaryInfo, setDiaryInfo] = useState<IDiaryInfo>({
     hashArr: [],
     moodValue: 5,
@@ -124,7 +121,11 @@ const EditDiary = () => {
     hashtags: [],
     hasImage: false,
   });
+
+  const diaryId = useParamsId();
   const { mutate } = usePatchDiary({ diaryId, file, requestDto });
+  const { date } = useTodayDate();
+  const { detail } = useDiaryDetail(diaryId);
 
   // 상태 업데이트 함수
   const setDiaryField = (field: Partial<IDiaryInfo>) => {
@@ -180,31 +181,6 @@ const EditDiary = () => {
     setDiaryField({ hashArr: diaryInfo.hashArr.filter((_, i) => i !== index) });
   };
 
-  useEffect(() => {
-    API.get<IDiaryInfo>(END_POINT.TODAY_DATE)
-      .then(response => {
-        setDiaryField({
-          year: response.data.year,
-          month: response.data.month,
-          date: response.data.date,
-          day: response.data.day,
-        });
-      })
-      .catch(error => {
-        console.error(CONSOLE_ERROR.DATE.GET + error);
-      });
-  }, []);
-
-  const checkWritingPermission = () => {
-    const lastWritingDate = localStorage.getItem('lastWritingDate');
-    const currentDate = `${diaryInfo.year}년/${diaryInfo.month}월/${diaryInfo.date}일`;
-
-    if (lastWritingDate === currentDate) {
-      return false;
-    }
-    return true;
-  };
-
   const handleSave = async () => {
     const { quillContent, isPrivate, hashArr, moodValue } = diaryInfo;
 
@@ -215,17 +191,6 @@ const EditDiary = () => {
       hashtags: hashArr,
       hasImage: hasImage,
     });
-
-    if (!checkWritingPermission()) {
-      Swal.fire({
-        title: ERROR.DIARY_ALREADY_EXISTS,
-        icon: 'warning',
-        showCancelButton: false,
-        confirmButtonColor: '#28CA3B',
-        confirmButtonText: '확인',
-      });
-      return;
-    }
 
     if (!quillContent || !quillContent.trim()) {
       Swal.fire({
@@ -241,28 +206,25 @@ const EditDiary = () => {
     mutate();
   };
 
-  // 수정 기능일 때의 코드
-
-  const fetchDiaryData = async () => {
-    try {
-      const response = await API.get(END_POINT.DIARY(diaryId));
-      const tags = response.data.tags.map((tag: ITages) => tag.tag);
-
-      setDiaryField({
-        hashArr: tags,
-        isPrivate: response.data.isPrivate,
-        moodValue: response.data.transparency * 10,
-        quillContent: response.data.content,
-      });
-      setImageURL(response.data.imageURL);
-    } catch (error) {
-      console.error(CONSOLE_ERROR.DIARY.GET + error);
-    }
-  };
-
   useEffect(() => {
-    fetchDiaryData();
-  }, []);
+    if (date) {
+      setDiaryField({
+        year: date.year,
+        month: date.month,
+        date: date.date,
+        day: date.day,
+      });
+    }
+    if (detail) {
+      setDiaryField({
+        hashArr: detail.tags.map((tag: ITages) => tag.tag),
+        isPrivate: detail.isPrivate,
+        moodValue: detail.transparency * 10,
+        quillContent: detail.content,
+      });
+      setImageURL(detail.imageURL);
+    }
+  }, [date, detail]);
 
   return (
     <Container>

--- a/grass-diary/src/pages/Main/TopSection.tsx
+++ b/grass-diary/src/pages/Main/TopSection.tsx
@@ -111,7 +111,7 @@ const TopSection = () => {
   });
 
   // 날짜 데이터를 가져오는 쿼리
-  const { data: date } = useTodayDate();
+  const { date } = useTodayDate();
 
   const modal = () => {
     Swal.fire({

--- a/grass-diary/src/pages/Main/TopSection.tsx
+++ b/grass-diary/src/pages/Main/TopSection.tsx
@@ -6,8 +6,8 @@ import API from '@services/index';
 import mainCharacter from '@icon/mainCharacter.png';
 import Swal from 'sweetalert2';
 import { END_POINT } from '@constants/api';
+import { useTodayDate } from '@hooks/api/useTodayDate';
 // import { QuestionResponse, DateResponse } from 'src/types/today';
-import { TodayInfo } from 'src/types/today';
 
 const TopSectionStyles = stylex.create({
   container: {
@@ -111,11 +111,7 @@ const TopSection = () => {
   });
 
   // 날짜 데이터를 가져오는 쿼리
-  const { data: date } = useQuery<TodayInfo>({
-    queryKey: ['todayDate'],
-    queryFn: () =>
-      API.get(END_POINT.TODAY_DATE).then(response => response.data),
-  });
+  const { data: date } = useTodayDate();
 
   const modal = () => {
     Swal.fire({

--- a/grass-diary/src/types/diary.ts
+++ b/grass-diary/src/types/diary.ts
@@ -76,3 +76,12 @@ interface IDiaryDetail extends IDiary {
   imageURL: string;
   likedByLogInMember: boolean;
 }
+
+// Create/Edit page api request Type
+type RequestDto = {
+  content: string;
+  isPrivate: boolean;
+  conditionLevel: string;
+  hashtags: string[];
+  hasImage: boolean;
+};

--- a/grass-diary/src/types/diary.ts
+++ b/grass-diary/src/types/diary.ts
@@ -69,7 +69,6 @@ interface IDiaryInfo {
 
 // DiaryDetail Type
 interface IDiaryDetail extends IDiary {
-  id: Id;
   memberId: Id;
   hasImage: null;
   hasTag: null;

--- a/grass-diary/src/types/today.ts
+++ b/grass-diary/src/types/today.ts
@@ -5,3 +5,10 @@ interface TodayInfo {
   date: number;
   day: string;
 }
+
+interface TodayDate {
+  year: number;
+  month: number;
+  date: number;
+  day: string;
+}

--- a/grass-diary/src/types/today.ts
+++ b/grass-diary/src/types/today.ts
@@ -6,9 +6,4 @@ interface TodayInfo {
   day: string;
 }
 
-interface TodayDate {
-  year: number;
-  month: number;
-  date: number;
-  day: string;
-}
+type TodayDate = Omit<TodayInfo, 'question'>;

--- a/grass-diary/src/types/today.ts
+++ b/grass-diary/src/types/today.ts
@@ -1,4 +1,4 @@
-export interface TodayInfo {
+interface TodayInfo {
   question: string;
   year: number;
   month: number;


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  usePatchDiary api 훅 생성
- [x]  useTodayDate api 훅 생성
- [x]  useDiaryDetail api 훅 에러 처리 수정
- [x]  EditDiary 페이지 Tanstack query 적용 
- [x]  localStroage의 lastWritingDate 사라짐 현상 해결

## 📝 작업 상세 내용

### 1️⃣ usePatchDiary 훅 생성 
일기 수정 PATCH `/api/diary/{diaryId}` api를 axios에서  useMutation을 활용한 Tanstack query로 변경하였습니다.  
```ts
export const usePatchDiary = ({ diaryId, file, requestDto }: PatchDiaryProps) => {
  ... 
  return useMutation({
    mutationFn: () => fetchAxios({ diaryId, formData }),
    onSuccess() {
      navigate(`/diary/${diaryId}`, { replace: true, state: 'editcomplete' });
    },
    onError(error) {
      console.error(error.message);
    },
  });
};
```
usePatchDiary 훅은 수정할 일기의 diaryId, 이미지 파일, requestDto를 인수로 받습니다. 
이 훅을 사용할 땐 아래처럼 mutate 함수를 사용해야합니다. 
```ts
  const { mutate } = usePatchDiary({ diaryId, file, requestDto });
```
mutate 함수는 일기 수정이 끝난 후 저장버튼을 눌렀을 때 실행되도록 했습니다. 그리고 mutate 함수를 통해 mutationFn의 fetchAxios가 실행되며 수정된 일기가 서버로 전송됩니다.

onSuccess는 patch가 성공적으로 완료되었을 때 실행됩니다. 일기 수정이 성공적으로 끝나면 수정된 일기 상세 페이지로 이동하도록 했습니다. 

onError는 patch에 실패했을 때 실행되는데 에러 메시지를 콘솔창에 띄워주도록 했습니다.   

### 2️⃣ useTodayDate 훅 생성 
#158 이슈의 문제를 해결하고자 서버에서 제공해주는 날짜 데이터를 이용하도록 변경하기 위해 `/api/main/today-date` api를 적용했습니다. 
이 api는 일기 상세 페이지 외에도 메인/작성/수정 페이지에서 사용되고 있어 Tanstack query를 사용한 useTodayDate 훅으로 만들어 사용하면 api 중복 요청을 해결하고 작성할 코드도 줄어듭니다.

아래가 useTodayDate 코드 입니다.
```ts
// TodayDate 타입은 types/today.ts 에 위치
interface TodayDate {
  year: number;
  month: number;
  date: number;
  day: string;
}

export const useTodayDate = () => {
  const { data: date, isError, error } = useQuery<TodayDate, AxiosError, TodayDate, [string]>({
    queryKey: ['todayDate'],
    queryFn: fetchAxios,
  });

  if (isError) console.error(CONSOLE_ERROR.DATE.GET + error.message);

  return { date };
};
```
useQuery 의 isError를 통해 오늘 날짜 정보를 가져오는데 실패했을 경우 콘솔 창에 에러메시지가 나타나도록 했습니다. 
사용할 땐 아래처럼 사용합니다. 
```ts
const { date } = useTodayDate();
```
date이름으로 retrun 하기 때문에 date 이름을 바로 사용할 수 있습니다. 
오늘의 날짜 정보가 필요한 **상세/메인/수정 페이지에 적용**해두었습니다!
-> (추가) **작성 페이지에도 적용**완료했습니다!**

## 🚨 버그 발생 이유 (선택 사항)
### 1️⃣ localStroage의 lastWritingDate 사라짐 현상 해결
용호님이 발견해주신 #151 오류를 해결했습니다. 

제가 예전에 일기 작성, 수정 테스트를 진행하면서 매번 개발자 도구를 통해 localStroage의 lastWritingDate를 삭제해주는 게 불편해 수정 페이지로 이동할 때 lastWritingDate 가 삭제되는 코드를 작성해두었었습니다. PR 올릴 때 이 코드를 제거하는 것을 깜박해 발생한 오류입니다..! 

해당 코드를 지우고 정상 동작 확인했습니다!  

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)


## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: Close #88 Close #151 Close #158
