### PR TITLE
✨ feat: 작성 페이지 이미지 임시 저장 구현

### DIFF
--- a/grass-diary/src/pages/CreateDiary/QuillEditor.tsx
+++ b/grass-diary/src/pages/CreateDiary/QuillEditor.tsx
@@ -5,13 +5,13 @@ import 'react-quill/dist/quill.snow.css';
 
 import { useState, useEffect, useMemo } from 'react';
 import { END_POINT } from '@constants/api';
-import { CONSOLE_ERROR, TOAST, QUILL_MESSAGE } from '@constants/message';
-import { useToast } from '@state/toast/useToast';
-
+import { CONSOLE_ERROR } from '@constants/message';
+import { QUILL_MESSAGE } from '@constants/message';
 
 type QuillEditorProps = {
   onContentChange: (content: string) => void;
   handleImageChange: (file: File) => void;
+  onImageBase64Change: (base64String: string) => void;
   selectedMode: string;
   quillContent: string;
   setImage: React.Dispatch<React.SetStateAction<DiaryImage>>;
@@ -28,6 +28,7 @@ const QuillEditor = ({
   setImage,
   setFile,
   handleImageChange,
+  onImageBase64Change,
   selectedMode,
 }: QuillEditorProps) => {
   const handleChange = (
@@ -40,7 +41,6 @@ const QuillEditor = ({
   };
 
   const [todayQuestion, setTodayQuestion] = useState<string>();
-  const { redToast } = useToast();
 
   const placeholderText =
     selectedMode === `customEntry`
@@ -55,12 +55,6 @@ const QuillEditor = ({
 
     input.onchange = () => {
       const file = input.files ? input.files[0] : null;
-      const maxSize = 5 * 1024 * 1024;
-
-      if (file && file.size > maxSize) {
-        redToast(TOAST.image_capacity_limit);
-        return;
-      }
 
       if (file) {
         const formData = new FormData();
@@ -72,10 +66,12 @@ const QuillEditor = ({
         const reader = new FileReader();
         reader.readAsDataURL(file);
         reader.onloadend = () => {
+          const base64String = reader.result as string;
           setImage({
             imageId: 0,
-            imageURL: reader.result as string,
+            imageURL: base64String,
           });
+          onImageBase64Change(base64String);
         };
       }
     };


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  글을 작성할 때 업로드 중인 이미지도 같이 로컬 스토리지에 저장 시켜 줍니다

## 📝 작업 상세 내용

### 임시 저장

1️⃣ 작성 글을 임시 저장할 때 로컬 스토리지에 diary_info와 같이 image 값을 저장해 줍니다.

![임시저장PR_1](https://github.com/user-attachments/assets/0f946797-8703-4879-a1a8-8ae7d5a73f68)
<br>


2️⃣ 기존에 `ImageHandler`함수에서 저장되는 변환된 base64 인코딩 값을 `onImageBase64Change`에 담아서 `CreateDiary` 컴포넌트에 보내줍니다

![임시저장PR_2](https://github.com/user-attachments/assets/5701ead7-7cfb-4ee1-8ebc-068d4d600dc4)
<br>

```ts
// QuillEditor

        const reader = new FileReader();
        reader.readAsDataURL(file);
        reader.onloadend = () => {
          const base64String = reader.result as string;
          setImage({
            imageId: 0,
            imageURL: base64String,
          });
          onImageBase64Change(base64String);
```

```ts
// CreateDiary

  const [imageBase64, setImageBase64] = useState<string | null>(null);

  const handleImageBase64Change = (base64String: string) => {
    setImageBase64(base64String);
  };
```

<br>

🚀 작성 페이지에서 임시 저장을 실행할 때 `diary_draft`에 `dirayInfo`와 같이 변환된 이미지 값 `imageBase64`, 이미지 정보 `imageInfo`를 저장 합니다.

```ts
// CreateDiray
const handleSaveDraft = () => {
    if (isContentEmpty) return; // 일기 내용이 비어 있으면 저장 요청 불가
    const draftData = {
      ...diaryInfo,
      imageBase64: imageBase64,
      imageInfo: {
        name: imageInfo.name,
        size: imageInfo.size,
      },
    };
    localStorage.setItem('diary_draft', JSON.stringify(draftData));
    toast(CREATE_MESSAGES.toast.temp_save);
  };
```
<br>

🤔 처음에 useEffect를 사용 할 땐 로컬 스토리지에 값이 잘 저장되는 것처럼 보였는데 정작 임시 저장 글을 저장할 때는 이미지가 휘발돼서 같이 저장이 되지 않았습니다

```ts
useEffect(() => {
    const savedDraft = localStorage.getItem('diary_draft');
    if (savedDraft) {
      const parsedDraft = JSON.parse(savedDraft);
      setDiaryInfo(parsedDraft);
      if (parsedDraft.imageBase64) {
        setImage({
          imageId: 0,
          imageURL: parsedDraft.imageBase64,
        });
        setImageBase64(parsedDraft.imageBase64);
        setImageInfo(parsedDraft.imageInfo || { name: '', size: '' });
```

<br>

3️⃣ Base64 문자열을 다시 File 객체로 변환하고 Formdata에 추가 합니다


![임시저장PR_3](https://github.com/user-attachments/assets/1b296312-ad87-45a8-b3c2-0c2a74e479dd)

<br>


```ts
useEffect(() => {
    const savedDraft = localStorage.getItem('diary_draft');
    if (savedDraft) {
      const parsedDraft = JSON.parse(savedDraft);
      setDiaryInfo(parsedDraft);
      if (parsedDraft.imageBase64) {
        setImage({
          imageId: 0,
          imageURL: parsedDraft.imageBase64,
        });
        setImageBase64(parsedDraft.imageBase64);
        setImageInfo(parsedDraft.imageInfo || { name: '', size: '' });
        // Base64를 File 객체로 변환
        fetch(parsedDraft.imageBase64)
          .then(res => res.blob())
          .then(blob => {
            const file = new File([blob], 'image.jpg', { type: 'image/jpeg' });
            const formData = new FormData();
            formData.append('image', file);
            setFile(formData);
          });
```

- Base64 문자열을 Blob으로 변환
- Blob을 이용해 새로운 File 객체를 생성
- File 객체를 FormData에 추가
- 이 FormData를 setFile을 통해 상태로 저장

저장돼있던 이미지 값이 다시 File 형태로 복원돼서 `file`에 저장합니다. 이렇게 되면 페이지를 벗어났다가 돌아와도 원래 상태로 복원이 됩니다
이전에는 File 객체의 재생성 과정이 없어서 `Base64`가 문자열로만 존재했고 실제 업로드를 할 땐 복원되지 않았지만 이 동작으로 정상 작동합니다!

<br>
<br>

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)
후에는 임시 저장 데이터를 서버에 저장하도록 변경? 🤔

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #194 
