### PR TITLE
🐛 fix: 릴리즈 이후 버그 및 개선사항 적용

### DIFF
--- a/grass-diary/src/components/Notification/Callout.tsx
+++ b/grass-diary/src/components/Notification/Callout.tsx
@@ -8,9 +8,7 @@ type CalloutProps = {
 const Callout = ({ message }: CalloutProps) => {
   return (
     <S.Container>
-      <S.Space>
-        <Info />
-      </S.Space>
+      <Info style={{ flexShrink: 0 }} />
       <S.Text>{message}</S.Text>
     </S.Container>
   );

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -75,13 +75,6 @@ const CreateDiary = () => {
 
     const button1 = {
       active: true,
-      text: MODAL.create_diary.continue_entry,
-      color: semantic.light.accent.solid.hero,
-      interaction: INTERACTION.accent.subtle(),
-    };
-
-    const button2 = {
-      active: true,
       text: MODAL.create_diary.new_entry,
       clickHandler: () => {
         localStorage.removeItem('diary_draft');
@@ -106,7 +99,15 @@ const CreateDiary = () => {
       },
     };
 
-    modal(setting, button2, button1);
+    const button2 = {
+      active: true,
+      text: MODAL.create_diary.continue_entry,
+      color: semantic.light.accent.solid.hero,
+      interaction: INTERACTION.accent.subtle(),
+      clickHandler: () => {},
+    };
+
+    modal(setting, button1, button2);
   };
 
   useEffect(() => {

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -372,44 +372,48 @@ const CreateDiary = () => {
           </S.SaveBtnContainer>
         </S.SaveWrap>
         <S.DiaryModeSelector>
-          <S.DailyQuestionBox $isSelected={selectedMode === 'dailyQuestion'}>
-            <S.ModeBtn>
-              <input
-                id="mode-btn-question"
-                type="radio"
-                checked={selectedMode === 'dailyQuestion'}
-                onChange={() => handleModeChange('dailyQuestion')}
-              />
-              <label htmlFor="mode-btn-question"></label>
-            </S.ModeBtn>
-            <S.ModeBoxContainer>
-              <S.DiaryModeSelectorText>
-                {CREATE_MESSAGES.question_title}
-              </S.DiaryModeSelectorText>
-              <S.DiaryModeSelectorSubText>
-                {CREATE_MESSAGES.question_prompt}
-              </S.DiaryModeSelectorSubText>
-            </S.ModeBoxContainer>
-          </S.DailyQuestionBox>
-          <S.CustomEntryBox $isSelected={selectedMode === 'customEntry'}>
-            <S.ModeBtn>
-              <input
-                id="mode-btn-custom"
-                type="radio"
-                checked={selectedMode === 'customEntry'}
-                onChange={() => handleModeChange('customEntry')}
-              />
-              <label htmlFor="mode-btn-custom"></label>
-            </S.ModeBtn>
-            <S.ModeBoxContainer>
-              <S.DiaryModeSelectorText>
-                {CREATE_MESSAGES.personal_diary}
-              </S.DiaryModeSelectorText>
-              <S.DiaryModeSelectorSubText>
-                {CREATE_MESSAGES.personal_prompt}
-              </S.DiaryModeSelectorSubText>
-            </S.ModeBoxContainer>
-          </S.CustomEntryBox>
+          <label htmlFor="mode-btn-question">
+            <S.DailyQuestionBox $isSelected={selectedMode === 'dailyQuestion'}>
+              <S.ModeBtn>
+                <input
+                  id="mode-btn-question"
+                  type="radio"
+                  checked={selectedMode === 'dailyQuestion'}
+                  onChange={() => handleModeChange('dailyQuestion')}
+                />
+                <label htmlFor="mode-btn-question"></label>
+              </S.ModeBtn>
+              <S.ModeBoxContainer>
+                <S.DiaryModeSelectorText>
+                  {CREATE_MESSAGES.question_title}
+                </S.DiaryModeSelectorText>
+                <S.DiaryModeSelectorSubText>
+                  {CREATE_MESSAGES.question_prompt}
+                </S.DiaryModeSelectorSubText>
+              </S.ModeBoxContainer>
+            </S.DailyQuestionBox>
+          </label>
+          <label htmlFor="mode-btn-custom">
+            <S.CustomEntryBox $isSelected={selectedMode === 'customEntry'}>
+              <S.ModeBtn>
+                <input
+                  id="mode-btn-custom"
+                  type="radio"
+                  checked={selectedMode === 'customEntry'}
+                  onChange={() => handleModeChange('customEntry')}
+                />
+                <label htmlFor="mode-btn-custom"></label>
+              </S.ModeBtn>
+              <S.ModeBoxContainer>
+                <S.DiaryModeSelectorText>
+                  {CREATE_MESSAGES.personal_diary}
+                </S.DiaryModeSelectorText>
+                <S.DiaryModeSelectorSubText>
+                  {CREATE_MESSAGES.personal_prompt}
+                </S.DiaryModeSelectorSubText>
+              </S.ModeBoxContainer>
+            </S.CustomEntryBox>
+          </label>
         </S.DiaryModeSelector>
         <S.Divider>
           <S.DividerLine />

--- a/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
+++ b/grass-diary/src/pages/CreateDiary/CreateDiary.tsx
@@ -445,7 +445,7 @@ const CreateDiary = () => {
           </S.HashtagTitleBox>
           <S.HashtagBox>
             <S.HashtagContent>
-              <Tag />
+              <Tag style={{ flexShrink: 0 }} />
               <S.HashtagArrTitle>
                 {diaryInfo.hashArr.map((tag, index) => (
                   <span key={index}>

--- a/grass-diary/src/styles/CreateDiary/CreateDiary.style.tsx
+++ b/grass-diary/src/styles/CreateDiary/CreateDiary.style.tsx
@@ -196,6 +196,8 @@ export const DailyQuestionBox = styled.div<{ $isSelected: boolean }>`
     props.$isSelected
       ? semantic.light.accent.transparent.alternative
       : semantic.light.bg.solid.normal};
+
+  cursor: pointer;
 `;
 
 export const CustomEntryBox = styled.div<{ $isSelected: boolean }>`
@@ -214,6 +216,8 @@ export const CustomEntryBox = styled.div<{ $isSelected: boolean }>`
     props.$isSelected
       ? semantic.light.accent.transparent.alternative
       : semantic.light.bg.solid.normal};
+
+  cursor: pointer;
 `;
 
 export const ModeBtn = styled.div`

--- a/grass-diary/src/styles/component/Notification/Callout.style.tsx
+++ b/grass-diary/src/styles/component/Notification/Callout.style.tsx
@@ -25,13 +25,3 @@ export const Text = styled.p`
     ${TYPO.caption1}
   }
 `;
-
-export const Space = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  @media screen and (max-width: 60em) {
-    font-size: 1em;
-  }
-`;

--- a/grass-diary/src/styles/component/Notification/Callout.style.tsx
+++ b/grass-diary/src/styles/component/Notification/Callout.style.tsx
@@ -6,7 +6,7 @@ export const Container = styled.div`
   display: flex;
   align-self: center;
   padding: var(--gap-3xs, 0.375rem) var(--gap-sm, 0.75rem);
-  align-items: flex-start;
+  align-items: center;
   gap: var(--gap-2xs, 0.5rem);
 
   border-radius: var(--radius-xs, 0.5rem);
@@ -27,6 +27,10 @@ export const Text = styled.p`
 `;
 
 export const Space = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   @media screen and (max-width: 60em) {
     font-size: 1em;
   }


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  임시저장 모달 button1 타입 에러
- [x]  이모지 작성 불가
- [x] 모드 셀렉터 박스 자체 클릭 가능하도록 개선
- [x] (모바일) 해시태그 UI 깨짐

## 📝 작업 상세 내용

### 1️⃣ 백엔드 Charset 로직 수정 후 이모지 사용

<img width="912" alt="스크린샷 2024-09-22 오후 6 17 49" src="https://github.com/user-attachments/assets/75848d53-4f1a-471b-baca-e582b5073238">

<br>

### 2️⃣ 모드 셀렉터 박스 개선

![모드셀렉터](https://github.com/user-attachments/assets/f96907d2-7297-4c83-acab-aef0d0d1a1cc)

label 요소를 부모 박스(DailyQuestionBox, CustomEntryBox)에 하나 더 추가하여 박스 전체를 클릭하면 라디오 버튼이 체크되도록 처리.

<br>

### 3️⃣ (모바일) 해시태그 UI 깨짐

<img width="371" alt="스크린샷 2024-09-22 오후 4 47 05" src="https://github.com/user-attachments/assets/fe4eb568-dda8-4830-a986-6e93e472feda">

<img width="369" alt="스크린샷 2024-09-22 오후 6 24 19" src="https://github.com/user-attachments/assets/51687463-93cc-48bd-9b6f-2846df286300">

<br>

svg 컴포넌트에 flex-shrink를 사용하여 고정된 영역을 가지도록 처리
콜아웃 컴포넌트도 같이 수정

<br>

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #[이슈 번호]
