### PR TITLE
🔨 fix: 액세스 토큰이 만료 시 로그아웃되지 않는 현상 수정

### DIFF
--- a/grass-diary/src/services/index.ts
+++ b/grass-diary/src/services/index.ts
@@ -17,16 +17,16 @@ API.interceptors.request.use(
   error => Promise.reject(error),
 );
 
-// API.interceptors.response.use(
-//   response => response,
-//   error => {
-//     if (error.response && error.response.status === 500) {
-//       localStorage.removeItem('accessToken');
-//       window.location.href = '/';
-//     }
+API.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('accessToken');
+      window.location.href = '/';
+    }
 
-//     return Promise.reject(error);
-//   },
-// );
+    return Promise.reject(error);
+  },
+);
 
 export default API;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 인가된 사용자가 아닐 경우 액세스 토큰 삭제 (에러 코드 변경)

## 📝 작업 상세 내용

> 기존에 아래 코드를 주석 처리 해 둠으로써 액세스 토큰이 만료되어도 자동으로 사용자 로그아웃이 진행되지 않는 버그가 발생했습니다. 아래 코드를 주석 처리 해 두었던 이유는 아래와 같습니다.

1. 로그인한 사용자의 액세스 토큰이 만료되어 `500 status code` 응답이 넘어오는 것으로 판단해 아래와 같은 코드를 작성함.
2. 로그인한 사용자가 메인 페이지로 넘어갔을 때, 오늘의 질문 API 응답이 넘어오지 않아 `500 status code`를 반환함.
3. 사용자가 로그인해도 오늘의 질문 API 오류로 인해 로그인이 되지 않고 소개 페이지로 계속해서 돌아오는 현상이 발생함.

→ 이러한 이유로 아래 코드를 주석 처리 하게 되면서 **사용자의 액세스 토큰이 만료되어도 해당 토큰이 로컬 스토리지에서 삭제되지 않고**, 이로 인해 **자동적으로 로그아웃되지 않는 버그가 지속적으로 발생**했습니다.

```ts
API.interceptors.response.use(
  response => response,
  error => {
    if (error.response && error.response.status === 500) {
      localStorage.removeItem('accessToken');
      window.location.href = '/';
    }

    return Promise.reject(error);
  },
);
```

금일 개발자 회의(9/22)에서 인가되지 않은 사용자가 서비스에 접근할 경우 `401 status code`를 반환하는 것을 확인하고 위 조건문의 조건을 아래와 같이 변경해 주었습니다. 즉, **사용자의 액세스 토큰이 만료될 경우 자동으로 액세스 토큰이 로컬 스토리지에서 삭제되면서 자동으로 로그아웃됩니다.** 

```ts
if (error.response && error.response.status === 401)
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #209 
