### PR TITLE
🔨 fix: 로그인 만료 로직 변경 

### DIFF
--- a/grass-diary/package-lock.json
+++ b/grass-diary/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.6.7",
         "dayjs": "^1.11.10",
         "dompurify": "^3.0.11",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.8.1",
@@ -9214,6 +9215,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/grass-diary/package.json
+++ b/grass-diary/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.6.7",
     "dayjs": "^1.11.10",
     "dompurify": "^3.0.11",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.8.1",

--- a/grass-diary/src/components/Layout/Header.tsx
+++ b/grass-diary/src/components/Layout/Header.tsx
@@ -5,11 +5,61 @@ import { Profile } from '@components/index';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '@state/user/useUser';
 import { useModal } from '@state/modal/useModal';
+import { useEffect } from 'react';
+import { MODAL } from '@constants/message';
+import { semantic } from '@styles/semantic';
+import { INTERACTION } from '@styles/interaction';
+import { useAuthExpDate } from '@state/auth/authStore';
+import useExpDate from '@state/auth/useExpDate';
+import useLogout from '@hooks/useLogout';
 
 const Header = () => {
   const memberId = useUser();
-  const { loginModal } = useModal();
+  const { loginModal, modal } = useModal();
   const navigate = useNavigate();
+  const clearAuth = useLogout();
+  const expDate = useAuthExpDate();
+  const { handleExpDate } = useExpDate();
+
+  const hasExpired = (expirationDate: Date) => {
+    if (!expirationDate) return false;
+    const currentDate = new Date();
+    const timeDiff = expirationDate.getTime() - currentDate.getTime();
+    return timeDiff <= 0 ? true : false;
+  };
+
+  // 로그인 만료 타이머
+  useEffect(() => {
+    let expireInterval: NodeJS.Timeout;
+    if (!expDate) handleExpDate();
+
+    if (expDate) {
+      expireInterval = setInterval(() => {
+        if (hasExpired(expDate)) {
+          const setting = {
+            title: MODAL.authentication_error.title,
+            content: MODAL.authentication_error.content,
+          };
+
+          const button1 = {
+            active: true,
+            text: MODAL.confirm,
+            color: semantic.light.accent.solid.hero,
+            interaction: INTERACTION.accent.subtle(),
+            clickHandler: () => (window.location.href = '/'),
+          };
+
+          clearAuth(true);
+          clearInterval(expireInterval);
+          modal(setting, button1);
+        }
+      }, 60000);
+    }
+
+    return () => {
+      if (expireInterval) clearInterval(expireInterval);
+    };
+  }, [memberId, expDate]);
 
   return (
     <S.Header>

--- a/grass-diary/src/hooks/useLogout.ts
+++ b/grass-diary/src/hooks/useLogout.ts
@@ -9,7 +9,7 @@ const useLogout = () => {
 
   const clearAuth = () => {
     localStorage.removeItem('accessToken');
-    localStorage.setItem('manualLogout', 'true');
+    localStorage.setItem('logout', 'true');
     setIsAuthenticated(false);
     setMemberId(0);
 

--- a/grass-diary/src/hooks/useLogout.ts
+++ b/grass-diary/src/hooks/useLogout.ts
@@ -7,12 +7,13 @@ const useLogout = () => {
   const { setIsAuthenticated } = useAuthActions();
   const setMemberId = useSetMemberId();
 
-  const clearAuth = () => {
+  const clearAuth = (isExp?: boolean) => {
     localStorage.removeItem('accessToken');
     localStorage.setItem('logout', 'true');
     setIsAuthenticated(false);
     setMemberId(0);
 
+    if (isExp) return;
     navigate('/');
   };
 

--- a/grass-diary/src/state/auth/authStore.ts
+++ b/grass-diary/src/state/auth/authStore.ts
@@ -5,21 +5,25 @@ import { create } from 'zustand';
 interface Actions {
   setIsAuthenticated: (isAuthenticated: boolean) => void;
   setIsLoading: (isLoading: boolean) => void;
+  setExpDate: (expDate: Date) => void;
   handleCheckAuth: () => Promise<void>;
 }
 
 interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
+  expDate: Date | null;
   actions: Actions;
 }
 
 const useAuthStore = create<AuthState>(set => ({
   isAuthenticated: false,
   isLoading: true,
+  expDate: null,
   actions: {
     setIsAuthenticated: isAuthenticated => set({ isAuthenticated }),
     setIsLoading: isLoading => set({ isLoading }),
+    setExpDate: expDate => set({ expDate }),
     handleCheckAuth: async () => {
       try {
         const isLoggedIn: boolean = await checkAuth();
@@ -36,5 +40,6 @@ const useAuthStore = create<AuthState>(set => ({
 
 export const useIsAuthenticated = () =>
   useAuthStore(state => state.isAuthenticated);
-export const useIsLoding = () => useAuthStore(state => state.isLoading);
+export const useIsLoading = () => useAuthStore(state => state.isLoading);
+export const useAuthExpDate = () => useAuthStore(state => state.expDate);
 export const useAuthActions = () => useAuthStore(state => state.actions);

--- a/grass-diary/src/state/auth/useAuth.ts
+++ b/grass-diary/src/state/auth/useAuth.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useAuthActions, useIsAuthenticated, useIsLoding } from './authStore';
+import { useAuthActions, useIsAuthenticated, useIsLoading } from './authStore';
 
 interface IUseAuthReturn {
   isAuthenticated: boolean;
@@ -8,7 +8,7 @@ interface IUseAuthReturn {
 
 export const useAuth = (): IUseAuthReturn => {
   const isAuthenticated = useIsAuthenticated();
-  const isLoading = useIsLoding();
+  const isLoading = useIsLoading();
   const { handleCheckAuth } = useAuthActions();
 
   useEffect(() => {

--- a/grass-diary/src/state/auth/useExpDate.ts
+++ b/grass-diary/src/state/auth/useExpDate.ts
@@ -1,0 +1,25 @@
+import { jwtDecode } from 'jwt-decode';
+import { useAuthActions } from './authStore';
+
+const useExpDate = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  const { setExpDate } = useAuthActions();
+
+  const handleExpDate = () => {
+    if (accessToken) {
+      try {
+        const decode = jwtDecode(accessToken);
+        if (!decode.exp) return;
+        const date = new Date(0);
+        date.setUTCSeconds(decode.exp);
+        setExpDate(date);
+      } catch (error) {
+        console.error('Failed to decode token:', error);
+      }
+    }
+  };
+
+  return { handleExpDate };
+};
+
+export default useExpDate;

--- a/grass-diary/src/state/modal/useModal.ts
+++ b/grass-diary/src/state/modal/useModal.ts
@@ -21,7 +21,7 @@ export const useModal = () => {
     setActive(true);
     setLogin(true);
     setSetting(setting);
-    localStorage.removeItem('manualLogout');
+    localStorage.removeItem('logout');
   };
 
   return { modal, loginModal };


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  5초마다 memberId 요청 대신 로그인 만료 타이머 구현하기

## 📝 작업 상세 내용

기존 코드는 memberId를 가져오는 useQuery를 5초마다 호출해서 로그인이 만료되었는지 확인했었습니다. 
setInterval 함수로 로그인 만료 타이머를 구현해 불필요한 api 요청을 줄이면서 로그인이 만료되었는지 확인하도록 변경했습니다. 

### authStore에 새로운 state 추가
- `expDate`: 로그인 만료 시각 저장
- `setExpDate`: expDate 업데이트 함수

### useExpDate 훅 생성
```ts
const useExpDate = () => {
  const accessToken = localStorage.getItem('accessToken');
  const { setExpDate } = useAuthActions();

  const handleExpDate = () => {
    if (accessToken) {
      try {
        const decode = jwtDecode(accessToken);
        if (!decode.exp) return;
        const date = new Date(0);
        date.setUTCSeconds(decode.exp);
        setExpDate(date);
      } catch (error) {
        console.error('Failed to decode token:', error);
      }
    }
  };

  return { handleExpDate };
};
```
- `handleExpDate`함수는 로그인이 만료되는 시각을 구해 expDate 상태를 업데이트합니다.
- 엑세스 토큰을 디코딩하면 만료 시각을 구할 수 있습니다. 
- 엑세스 토큰을 반환하는데 `jwt-decode` 라이브러리를 사용합니다. 
참고: [쉽게 이해하는 jwt-decode 라이브러리](https://ha-jenong.tistory.com/143)

### Header 컴포넌트에 로그인 만료 타이머 구현

```ts
const hasExpired = (expirationDate: Date) => {
  if (!expirationDate) return false;
  const currentDate = new Date();
  const timeDiff = expirationDate.getTime() - currentDate.getTime();
  return timeDiff <= 0 ? true : false;
};
```
- hasExpired 함수는 엑세스 토큰이 만료되었다면 true, 아니라면 false를 리턴합니다.
- 인수로 받은 만료 시각과 현재 시각의 차이를 구해 0보다 작다면 true를 리턴합니다. 

```ts
  useEffect(() => {
    let expireInterval: NodeJS.Timeout; 
    if (!expDate) handleExpDate(); // 만료 시각이 null이라면 구합니다.
    
    if (expDate) {
      expireInterval = setInterval(() => {
        if (hasExpired(expDate)) { // 엑세스 토큰이 만료되었다면
          const setting = {
            title: MODAL.authentication_error.title,
            content: MODAL.authentication_error.content,
          };

          const button1 = {
            active: true,
            text: MODAL.confirm,
            color: semantic.light.accent.solid.hero,
            interaction: INTERACTION.accent.subtle(),
            clickHandler: () => (window.location.href = '/'),
          };

          clearAuth(true); // 로그아웃시키기
          clearInterval(expireInterval); // setInterval 실행 정지
          modal(setting, button1); // 모달 띄우기
        }
      }, 60000);
    }

    return () => {
      if (expireInterval) clearInterval(expireInterval);
    };
  }, [memberId, expDate]);
```
- `1분(60000ms)`마다 만료 시각과 현재 시각을 비교하여 만료되었는지 확인합니다. 
- 만료되었다면 로그아웃을 시키고 모달을 띄웁니다. 
- 모달의 `확인` 버튼 클릭 시 소개페이지로 이동합니다. 
  - 이를 위해 `useLogout`을 조금 수정했습니다. 
  - `clearAuth()`에 `isExp` 인수가 있을 경우에는 소개페이지 이동 코드가 실행되지 않도록 했습니다.

setInterval은 1분마다 로그인 만료를 확인하는데 이때 확인되는 만료에 의해 모달이 뜰 경우, `로그인 만료 시간 30분이 지나\n자동으로 로그아웃 되었어요` 메시지가 나타납니다. 하지만 setInterval 함수가 먼저 만료를 확인하지 못한 상태에서 사용자가 페이지 이동/새로고침으로 엑세스 토큰이 만료된 것을 알게 되었을 경우에는 useUser 내부의 401에러 모달이 나타납니다. 이 경우 `액세스 토큰 추출에 실패했습니다. 다시 로그인 해주세요` 메시지가 나타납니다.


## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: Close #227 
